### PR TITLE
Expose more information getAssignmentLatestSubmissions

### DIFF
--- a/src/main/kotlin/org/dropProject/controllers/TeacherAPIController.kt
+++ b/src/main/kotlin/org/dropProject/controllers/TeacherAPIController.kt
@@ -22,6 +22,7 @@ package org.dropProject.controllers
 import com.fasterxml.jackson.annotation.JsonView
 import io.swagger.annotations.*
 import org.dropProject.dao.*
+import org.dropProject.data.AssignmentLatestSubmissionsResponse
 import org.dropProject.data.JSONViews
 import org.dropProject.data.StudentHistory
 import org.dropProject.data.SubmissionInfo
@@ -88,11 +89,11 @@ class TeacherAPIController(
         response = SubmissionInfo::class, responseContainer = "List", ignoreJsonView = false
     )
     fun getAssignmentLatestSubmissions(@PathVariable assignmentId: String, model: ModelMap,
-                                      principal: Principal, request: HttpServletRequest): ResponseEntity<List<SubmissionInfo>> {
+                                      principal: Principal, request: HttpServletRequest): ResponseEntity<List<AssignmentLatestSubmissionsResponse>> {
         assignmentService.getAllSubmissionsForAssignment(assignmentId, principal, model, request, mode = "summary")
 
         val result = (model["submissions"] as List<SubmissionInfo>).map{
-            SubmissionInfo(it.projectGroup, it.lastSubmission, listOf())
+            AssignmentLatestSubmissionsResponse(it.projectGroup, it.lastSubmission, it.allSubmissions.size)
         }
 
         return ResponseEntity.ok(result)

--- a/src/main/kotlin/org/dropProject/data/AssignmentLatestSubmissionsResponse.kt
+++ b/src/main/kotlin/org/dropProject/data/AssignmentLatestSubmissionsResponse.kt
@@ -1,0 +1,33 @@
+/*-
+ * ========================LICENSE_START=================================
+ * DropProject
+ * %%
+ * Copyright (C) 2019 - 2024 Pedro Alves
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.dropProject.data
+
+import com.fasterxml.jackson.annotation.JsonView
+import org.dropProject.dao.ProjectGroup
+import org.dropProject.dao.Submission
+
+data class AssignmentLatestSubmissionsResponse(
+    @JsonView(JSONViews.TeacherAPI::class)
+    val projectGroup: ProjectGroup,
+    @JsonView(JSONViews.TeacherAPI::class)
+    val lastSubmission: Submission,
+    @JsonView(JSONViews.TeacherAPI::class)
+    val numSubmissions: Int
+)

--- a/src/test/kotlin/org/dropProject/controllers/TeacherAPIControllerTests.kt
+++ b/src/test/kotlin/org/dropProject/controllers/TeacherAPIControllerTests.kt
@@ -251,13 +251,22 @@ class TeacherAPIControllerTests: APIControllerTests {
             .andExpect(status().isOk)
             .andExpect(content().json("""
                 [
-                   {"projectGroup":{"id":1,"authors":[{"id":1,"name":"Student 1"}]},
-                    "lastSubmission":{"id":2,
-                                      "submissionDate":"2019-01-02T11:05:03.000+00:00",
-                                      "status":"VALIDATED",
-                                      "statusDate":"2019-01-02T11:05:03.000+00:00",
-                                      "markedAsFinal":false },
-                    "allSubmissions":[] }
+                  {"projectGroup": {"id": 1,"authors": [{"id": 1,"name": "Student 1"}]},
+                   "lastSubmission": {"id": 2,
+                                      "submissionDate": "2019-01-02T11:05:03.000+00:00",
+                                      "status": "VALIDATED",
+                                      "statusDate": "2019-01-02T11:05:03.000+00:00",
+                                      "markedAsFinal": false,
+                                      "teacherTests": {"numTests": 4,
+                                                       "numFailures": 0,
+                                                       "numErrors": 0,
+                                                       "numSkipped": 0,
+                                                       "ellapsed": 0.007,
+                                                       "numMandatoryOK": 0,
+                                                       "numMandatoryNOK": 0 },
+                                      "group": {"id": 1,
+                                                "authors": [{"id": 1,"name": "Student 1" }]} },
+                    "numSubmissions": 4 }
                 ]
             """.trimIndent()))
     }


### PR DESCRIPTION
This exposes necessary information (last submission info + submission count per group) to reach feature parity with the web UI on the assignment submissions overview.