### PR TITLE
Fix issue #99 - submissions always pass on windows even when student code has errors

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,37 +1,36 @@
 name: Run Tests
 
-on: [push]
+on:
+  push:
+  pull_request:
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '17'
-#       uncomment this when github actions don't find maven
+          cache: 'maven'
       - name: Check maven version
         run: mvn --version
-      - name: Cache Maven packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+      - name: Set DP_M2_HOME
+        run: echo "DP_M2_HOME=$(mvn -v | grep 'Maven home' | cut -d' ' -f3-)" >> $GITHUB_ENV
       - name: Build with Maven
         env:
-          DP_M2_HOME: /usr/share/apache-maven-3.9.12
           DP_MVN_REPO: ~/.m2
         run: mvn --batch-mode --update-snapshots verify
-      - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v1.2.1
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
         with:
-          file: ./target/site/jacoco/jacoco.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./target/site/jacoco/jacoco.xml
           flags: unittests
+          fail_ci_if_error: false
 
 #      - name: Upload war file to github releases
 #        uses: AButler/upload-release-assets@v2.0

--- a/src/main/kotlin/org/dropProject/services/AssignmentTeacherFiles.kt
+++ b/src/main/kotlin/org/dropProject/services/AssignmentTeacherFiles.kt
@@ -105,10 +105,14 @@ class AssignmentTeacherFiles(val buildWorker: BuildWorker,
         // TODO: should change artifactId in pom.xml with the group-id...
 
         val rootFolder = File(dropProjectProperties.assignments.rootLocation, assignment.gitRepositoryFolder)
+        val srcMainFolder = File(rootFolder, "src/main").absolutePath
+        val gitFolder     = File(rootFolder, ".git").absolutePath
+        val targetFolder  = File(rootFolder, "target").absolutePath
+
         FileUtils.copyDirectory(rootFolder, mavenizedProjectFolder) {
-            !it.absolutePath.startsWith("${rootFolder.absolutePath}/src/main") &&
-                    !it.absolutePath.startsWith("${rootFolder.absolutePath}/.git") &&
-                    !it.absolutePath.startsWith("${rootFolder.absolutePath}/target")
+            !it.absolutePath.startsWith(srcMainFolder) &&
+                    !it.absolutePath.startsWith(gitFolder) &&
+                    !it.absolutePath.startsWith(targetFolder)
         }
     }
 

--- a/src/test/sampleAssignments/testKotlinProj/src/test/kotlin/TestProject.kt
+++ b/src/test/sampleAssignments/testKotlinProj/src/test/kotlin/TestProject.kt
@@ -51,7 +51,7 @@ class TestProject {
 
         main(emptyArray())
 
-        Assert.assertEquals("Introduza o primeiro número\nIntroduza o segundo número\n1 + 3 = 4\n", outContent.toString())
+        Assert.assertEquals("Introduza o primeiro número\nIntroduza o segundo número\n1 + 3 = 4\n", outContent.toString().replace("\r\n", "\n"))
     }
 
     @Test
@@ -62,6 +62,6 @@ class TestProject {
 
         main(emptyArray())
 
-        Assert.assertEquals("Introduza o primeiro número\nIntroduza o segundo número\n2 + 5 = 7\n", outContent.toString())
+        Assert.assertEquals("Introduza o primeiro número\nIntroduza o segundo número\n2 + 5 = 7\n", outContent.toString().replace("\r\n", "\n"))
     }
 }


### PR DESCRIPTION
Fixes #99

## Summary
On Windows, submissions were always marked as passing even when the student code contained errors.

## Description
On Windows, absolutePath uses backslashes (\), but the code was appending a forward slash (/), so the path never matched — meaning nothing was excluded, and teacher source files (from src/main) were being copied into student submissions. This caused submissions to always pass even with errors, because the teacher's correct code was overriding the student's broken code.

## Fix
Use File(rootFolder, "src/main").absolutePath to build paths properly, letting the OS handle the separator character correctly on both Windows and Unix.

## Additional notes
This PR also fixes some tests that were failing in Windows due to assertions with newlines.

