### PR TITLE
Fix/checkstyle to run tests in english and Fix/issue#93

### DIFF
--- a/src/main/kotlin/org/dropProject/services/MavenInvoker.kt
+++ b/src/main/kotlin/org/dropProject/services/MavenInvoker.kt
@@ -88,6 +88,9 @@ class MavenInvoker(
             dpArgLine += " -DdropProject.currentUserId=${principalName}"
         }
 
+        // added this line to force the checkstyle to use English as the primary language
+        request.mavenOpts = "-Duser.language=en -Duser.country=US"
+
         if (securityManagerEnabled) {
             dpArgLine += " -Djava.security.manager=org.dropproject.security.SandboxSecurityManager"
             dpArgLine += " -DdropProject.maven.repository=${File(dropProjectProperties.maven.repository).absolutePath}"

--- a/src/main/kotlin/org/dropProject/services/SubmissionService.kt
+++ b/src/main/kotlin/org/dropProject/services/SubmissionService.kt
@@ -127,11 +127,10 @@ class SubmissionService(
             }
 
             if (retrieveReport) {
-                lastSubmission.buildReport?.let {
-                        buildReportDB ->
-                    val reportElements = submissionReportRepository.findBySubmissionId(lastSubmission.id)
-                    lastSubmission.reportElements = reportElements
+                val reportElements = submissionReportRepository.findBySubmissionId(lastSubmission.id)
+                lastSubmission.reportElements = reportElements
 
+                lastSubmission.buildReport?.let { buildReportDB ->
                     val mavenizedProjectFolder = assignmentTeacherFiles.getProjectFolderAsFile(lastSubmission,
                         lastSubmission.getStatus() == SubmissionStatus.VALIDATED_REBUILT)
                     val buildReport = buildReportBuilder.build(buildReportDB.buildReport.split("\n"),
@@ -142,7 +141,6 @@ class SubmissionService(
                     if (buildReport.jacocoResults.isNotEmpty()) {
                         lastSubmission.coverage = buildReport.jacocoResults[0].lineCoveragePercent
                     }
-
                     lastSubmission.testResults = buildReport.testResults()
                 }
             }

--- a/src/test/kotlin/org/dropProject/controllers/UploadControllerTests.kt
+++ b/src/test/kotlin/org/dropProject/controllers/UploadControllerTests.kt
@@ -2095,6 +2095,32 @@ class UploadControllerTests {
         val structureErrors = reportResult.modelAndView!!.modelMap["structureErrors"] as List<String>
         assertTrue("Should have errors about missing Maven structure", structureErrors.isNotEmpty())
     }
+
+    @Test
+    @DirtiesContext
+    fun uploadProjectInvalidStructure_IndicatorsShouldBeVisibleInReport() {
+
+        val submissionId = testsHelper.uploadProject(this.mvc, "projectInvalidStructure1", "testJavaProj", STUDENT_1)
+
+        // status should remain VALIDATED
+        val submissionFromDB = submissionRepository.findById(submissionId.toLong()).get()
+        assertEquals(SubmissionStatus.VALIDATED, submissionFromDB.getStatus())
+
+        // check that the report page shows the PROJECT_STRUCTURE indicator
+        val reportResult = this.mvc.perform(get("/report/testJavaProj").with(user(TEACHER_1)))
+            .andExpect(status().isOk)
+            .andReturn()
+
+        @Suppress("UNCHECKED_CAST")
+        val submissions = reportResult.modelAndView!!.modelMap["submissions"] as List<SubmissionInfo>
+        assertEquals(1, submissions.size)
+
+        val lastSubmission = submissions[0].lastSubmission
+        assertNotNull("reportElements should not be null", lastSubmission.reportElements)
+        assertTrue("reportElements should not be empty", lastSubmission.reportElements!!.isNotEmpty())
+        assertEquals(Indicator.PROJECT_STRUCTURE, lastSubmission.reportElements!![0].indicator)
+        assertEquals("NOK", lastSubmission.reportElements!![0].reportValue)
+    }
 }
 
 


### PR DESCRIPTION
## PR Title
Fix missing indicator for Project Structure errors + Force English for test executio
Closes#93

---

## Description
This PR addresses two issues:
1. Submissions with Project Structure errors were displayed as **"Validated"** but showed no visual indicator in the **"Indicators"** column.
2. Tests were failing on machines with non-English system locale (e.g. Portuguese).

---

## Root Cause

### Project Structure Indicator
In `SubmissionService.kt`, the `reportElements` were being fetched inside the `buildReport?.let { }` block. This meant that submissions without a `buildReport` (such as those with Project Structure errors) never had their `reportElements` populated, resulting in an empty Indicators column in the UI.

### Locale Issue
While running the test suite, most of the tests were failling, but one message appeared in Portuguese, which was unexpected. After investigation, it became clear that having the OS language set to Portuguese was preventing the tests from executing correctly. Switching the system language to English allowed all tests to pass, confirming the root cause.

---

## Solution

### Project Structure Indicator
In `SubmissionService.kt`, moved the `reportElements` fetch outside of the `buildReport?.let { }` block, so that it is always executed regardless of whether a `buildReport` exists.

**Before:**
```kotlin
if (retrieveReport) {
    lastSubmission.buildReport?.let { buildReportDB ->
        val reportElements = submissionReportRepository.findBySubmissionId(lastSubmission.id)
        lastSubmission.reportElements = reportElements
        // ...
    }
}
```

**After:**
```kotlin
if (retrieveReport) {
    val reportElements = submissionReportRepository.findBySubmissionId(lastSubmission.id)
    lastSubmission.reportElements = reportElements

    lastSubmission.buildReport?.let { buildReportDB ->
        // ...
    }
}
```

### Locale Fix
- Added `request.mavenOpts = "-Duser.language=en -Duser.country=US"` in `MavenInvoker.kt` to force Maven to always run with English locale, regardless of the OS language.
- After applying the fix, the system language was set back to Portuguese and all tests were confirmed to pass.

---

## Result
- Submissions remain **"Validated"** as intended.
- A visual indicator (❌) is now shown when a Project Structure error exists.
- UI feedback is now consistent with the build report.
- All tests pass regardless of the system locale.

---

## Testing

### Project Structure Indicator
1. Submit a project with an invalid structure (e.g., wrong package name).
2. Log in as a teacher.
3. Navigate to the submissions list.
4. Verify that:
   - The submission status is **"Validated"**
   - A red cross (❌) appears in the **Indicators** column

### Locale Fix
1. Set system locale to Portuguese.
2. Run the full test suite.
3. Verify all tests pass without locale-related failures.