### PR TITLE
Fix #100: Validate ACL user IDs format

### DIFF
--- a/src/main/kotlin/org/dropProject/controllers/AssignmentController.kt
+++ b/src/main/kotlin/org/dropProject/controllers/AssignmentController.kt
@@ -294,6 +294,16 @@ class AssignmentController(
         if (!(assignmentForm.acl.isNullOrBlank())) {
             val userIds = assignmentForm.acl!!.split(",")
 
+            // validate each userId
+            for (userId in userIds) {
+                val trimmedUserId = userId.trim()
+                if (trimmedUserId.contains(" ")) {
+                    bindingResult.rejectValue("acl", "acl.invalidFormat",
+                        "Error: User IDs must be comma-separated. '$trimmedUserId' appears to contain spaces.")
+                    return "assignment-form"
+                }
+            }
+
             // first delete existing to prevent duplicates
             assignmentACLRepository.deleteByAssignmentId(assignmentForm.assignmentId!!)
 

--- a/src/main/kotlin/org/dropProject/controllers/AssignmentController.kt
+++ b/src/main/kotlin/org/dropProject/controllers/AssignmentController.kt
@@ -294,12 +294,12 @@ class AssignmentController(
         if (!(assignmentForm.acl.isNullOrBlank())) {
             val userIds = assignmentForm.acl!!.split(",")
 
-            // validate each userId
+            // Validate each userId
             for (userId in userIds) {
                 val trimmedUserId = userId.trim()
-                if (trimmedUserId.contains(" ")) {
+                if (trimmedUserId.contains(" ") || trimmedUserId.contains(";")) {
                     bindingResult.rejectValue("acl", "acl.invalidFormat",
-                        "Error: User IDs must be comma-separated. '$trimmedUserId' appears to contain spaces.")
+                        "Error: User IDs must be comma-separated. '$trimmedUserId' contains invalid characters (spaces or semicolons).")
                     return "assignment-form"
                 }
             }

--- a/src/test/kotlin/org/dropProject/controllers/AssignmentControllerTests.kt
+++ b/src/test/kotlin/org/dropProject/controllers/AssignmentControllerTests.kt
@@ -2085,5 +2085,45 @@ class AssignmentControllerTests {
             }
         }
     }
+
+    @Test
+    @WithMockUser("teacher1", roles = ["TEACHER"])
+    @DirtiesContext
+    fun test_33_createAssignmentWithACLContainingSpaces() {
+
+        mvc.perform(
+            post("/assignment/new")
+                .param("assignmentId", "assignmentId")
+                .param("assignmentName", "assignmentName")
+                .param("assignmentPackage", "assignmentPackage")
+                .param("language", "JAVA")
+                .param("submissionMethod", "UPLOAD")
+                .param("gitRepositoryUrl", sampleJavaAssignmentRepo)
+                .param("acl", "teacher2 teacher3")  // space instead of comma
+        )
+            .andExpect(status().isOk())
+            .andExpect(view().name("assignment-form"))
+            .andExpect(model().attributeHasFieldErrors("assignmentForm", "acl"))
+    }
+
+    @Test
+    @WithMockUser("teacher1", roles = ["TEACHER"])
+    @DirtiesContext
+    fun test_34_createAssignmentWithACLContainingSemicolons() {
+
+        mvc.perform(
+            post("/assignment/new")
+                .param("assignmentId", "assignmentId")
+                .param("assignmentName", "assignmentName")
+                .param("assignmentPackage", "assignmentPackage")
+                .param("language", "JAVA")
+                .param("submissionMethod", "UPLOAD")
+                .param("gitRepositoryUrl", sampleJavaAssignmentRepo)
+                .param("acl", "teacher2;teacher3")  // semicolon instead of comma
+        )
+            .andExpect(status().isOk())
+            .andExpect(view().name("assignment-form"))
+            .andExpect(model().attributeHasFieldErrors("assignmentForm", "acl"))
+    }
 }
     


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
Fixes #100

When entering multiple teacher IDs in the "Other teachers (optional)" field without commas (e.g., using spaces like `teacher1 teacher2`), the system accepts the input as a single invalid user ID. No validation error is shown.

### What is the new behavior?

The system now validates that each user ID does not contain spaces. If spaces are detected, a clear error message is shown:
> "Error: User IDs must be comma-separated. 'teacher1 teacher2' appears to contain spaces."

### Other information?

* This is not a breaking change
* **How did you test:** Manually tested by attempting to save an assignment with `teacher1 teacher2` (space instead of comma) and verified the error message appears correctly. Also tested with valid comma-separated values to ensure normal functionality still works.