### PR TITLE
fix: remove extra slash in leaderboard group URL

### DIFF
--- a/src/main/resources/templates/leaderboard.html
+++ b/src/main/resources/templates/leaderboard.html
@@ -51,7 +51,7 @@
 
             <td th:if="${!isTeacher}" th:text="${submission.group.id}"></td>
             <td th:if="${isTeacher}">
-                <a th:href="@{/submissions/(assignmentId=${submission.assignmentId},groupId=${submission.group.id})}"
+                <a th:href="@{/submissions(assignmentId=${submission.assignmentId},groupId=${submission.group.id})}"
                    th:text="${submission.group.id}" th:title="${submission.group.authorsNameStr()}"></a>
             </td>
 


### PR DESCRIPTION
Fixes #110

## Problem
When clicking a group number on the Leaderboard page, the URL generated had an extra `/` before the query string:
- Current (broken): `/submissions/?assignmentId=sampleJavaProject&groupId=1`
- Expected: `/submissions?assignmentId=sampleJavaProject&groupId=1`

This caused a 404 error because the route `/submissions/` does not exist.

## Root Cause
In `leaderboard.html`, the Thymeleaf URL expression used `@{/submissions/(param=value)}` which generates a trailing slash before the query string. The correct syntax is `@{/submissions(param=value)}` without the slash before the parenthesis.

## Fix
Removed the extra `/` before `(` in the Thymeleaf `th:href` attribute on line 54 of `leaderboard.html`.

```html
<!-- Before -->
<a th:href="@{/submissions/(assignmentId=${submission.assignmentId},groupId=${submission.group.id})}">

<!-- After -->
<a th:href="@{/submissions(assignmentId=${submission.assignmentId},groupId=${submission.group.id})}">
```

## Testing
1. Start the application locally
2. Log in as teacher
3. Enable leaderboard on an assignment with submissions
4. Navigate to the leaderboard
5. Click a group number — the submission history page now loads correctly without 404

<img width="1519" height="514" alt="image" src="https://github.com/user-attachments/assets/a8195492-2096-4d4e-9b71-4089b5732932" />
