### PR TITLE
fix(leaderboard): remove trailing slash before path variables in group link

### DIFF
--- a/src/main/resources/templates/leaderboard.html
+++ b/src/main/resources/templates/leaderboard.html
@@ -51,7 +51,7 @@
 
             <td th:if="${!isTeacher}" th:text="${submission.group.id}"></td>
             <td th:if="${isTeacher}">
-                <a th:href="@{/submissions/(assignmentId=${submission.assignmentId},groupId=${submission.group.id})}"
+                <a th:href="@{/submissions(assignmentId=${submission.assignmentId},groupId=${submission.group.id})}"
                    th:text="${submission.group.id}" th:title="${submission.group.authorsNameStr()}"></a>
             </td>
 


### PR DESCRIPTION
## Summary

The leaderboard **Show Group** button generates a URL with a double slash due to an extraneous `/` before Thymeleaf path variable syntax. This causes a 404 error when teachers click the group button.

**Root cause:** In `leaderboard.html` line 54, the expression `@{/submissions/(...)` places a `/` immediately before `(`, which resolves as two separate path segments instead of path variables — producing the malformed href.

**Fix:** Remove the trailing slash so the expression becomes `@{/submissions(...)}`, which correctly resolves to the intended URL.

Fixes #110

## Changes

- **1 file changed**, 1 line modified in `leaderboard.html`
