### PR TITLE
fix: remove extra slash in leaderboard group URL (#110)

### DIFF
--- a/src/main/resources/templates/leaderboard.html
+++ b/src/main/resources/templates/leaderboard.html
@@ -51,7 +51,7 @@
 
             <td th:if="${!isTeacher}" th:text="${submission.group.id}"></td>
             <td th:if="${isTeacher}">
-                <a th:href="@{/submissions/(assignmentId=${submission.assignmentId},groupId=${submission.group.id})}"
+                <a th:href="@{/submissions(assignmentId=${submission.assignmentId},groupId=${submission.group.id})}"
                    th:text="${submission.group.id}" th:title="${submission.group.authorsNameStr()}"></a>
             </td>
 

--- a/src/test/kotlin/org/dropProject/controllers/ReportControllerTests.kt
+++ b/src/test/kotlin/org/dropProject/controllers/ReportControllerTests.kt
@@ -1333,4 +1333,26 @@ class ReportControllerTests {
             .andExpect(status().isNotFound)
     }
 
+
+
+
+@Test
+    @DirtiesContext
+    fun `leaderboard group URL has no extra slash`() {
+        val assignment = assignmentRepository.findById(defaultAssignmentId).get()
+        assignment.showLeaderBoard = true
+        assignment.leaderboardType = LeaderboardType.ELLAPSED
+        assignmentRepository.save(assignment)
+
+        val result = this.mvc.perform(
+            get("/leaderboard/testJavaProj")
+                .with(user(TEACHER_1))
+        )
+            .andExpect(status().isOk)
+            .andReturn()
+
+        val content = result.response.contentAsString
+        assert(!content.contains("/submissions/(")) { "URL should not contain /submissions/(" }
+    }
+
 }

--- a/src/test/kotlin/org/dropProject/controllers/ReportControllerTests.kt
+++ b/src/test/kotlin/org/dropProject/controllers/ReportControllerTests.kt
@@ -1366,6 +1366,6 @@ class ReportControllerTests {
             .andReturn()
 
         val content = result.response.contentAsString
-        assert(!content.contains("/submissions/?")) { "URL should not contain /submissions/? - extra slash found before query string" }
+        assert(content.contains("/submissions?assignmentId=")) { "URL should contain /submissions?assignmentId= -  no extra slash found before query string" }
     }
 }

--- a/src/test/kotlin/org/dropProject/controllers/ReportControllerTests.kt
+++ b/src/test/kotlin/org/dropProject/controllers/ReportControllerTests.kt
@@ -1344,6 +1344,20 @@ class ReportControllerTests {
         assignment.leaderboardType = LeaderboardType.ELLAPSED
         assignmentRepository.save(assignment)
 
+        val projectRoot = resourceLoader.getResource("file:src/test/sampleProjects/compact/java/projectOK").file
+        val path = File(projectRoot, "AUTHORS.txt").toPath()
+        val lines = Files.readAllLines(path)
+
+        try {
+            testsHelper.uploadProject(this.mvc, "projectOK", defaultAssignmentId, STUDENT_1)
+        } finally {
+            val writer = Files.newBufferedWriter(path)
+            writer.write(lines[0])
+            writer.newLine()
+            writer.write(lines[1])
+            writer.close()
+        }
+
         val result = this.mvc.perform(
             get("/leaderboard/testJavaProj")
                 .with(user(TEACHER_1))
@@ -1352,6 +1366,6 @@ class ReportControllerTests {
             .andReturn()
 
         val content = result.response.contentAsString
-        assert(!content.contains("@{/submissions/(")) { "URL should not contain @{/submissions/( - extra slash found" }
+        assert(!content.contains("/submissions/?")) { "URL should not contain /submissions/? - extra slash found before query string" }
     }
 }

--- a/src/test/kotlin/org/dropProject/controllers/ReportControllerTests.kt
+++ b/src/test/kotlin/org/dropProject/controllers/ReportControllerTests.kt
@@ -1336,7 +1336,7 @@ class ReportControllerTests {
 
 
 
-@Test
+    @Test
     @DirtiesContext
     fun `leaderboard group URL has no extra slash`() {
         val assignment = assignmentRepository.findById(defaultAssignmentId).get()
@@ -1352,7 +1352,6 @@ class ReportControllerTests {
             .andReturn()
 
         val content = result.response.contentAsString
-        assert(!content.contains("/submissions/(")) { "URL should not contain /submissions/(" }
+        assert(!content.contains("@{/submissions/(")) { "URL should not contain @{/submissions/( - extra slash found" }
     }
-
 }


### PR DESCRIPTION
Fixes #110

## Problem
When clicking a group number on the Leaderboard page, the URL generated had an extra `/` before the query string:
- Current (broken): `/submissions/?assignmentId=sampleJavaProject&groupId=1`
- Expected: `/submissions?assignmentId=sampleJavaProject&groupId=1`

This caused a 404 error because the route `/submissions/` does not exist.

## Root Cause
In `leaderboard.html`, the Thymeleaf URL expression used `@{/submissions/(param=value)}` which generates a trailing slash before the query string. The correct syntax is `@{/submissions(param=value)}` without the slash before the parenthesis.

## Fix
Removed the extra `/` before `(` in the Thymeleaf `th:href` attribute in `leaderboard.html`.

## Testing
1. Start the application locally
2. Log in as teacher
3. Enable leaderboard on an assignment with submissions
4. Navigate to the leaderboard
5. Click a group number — the submission history page now loads correctly without 404