### PR TITLE
fix: add validation to reject invalid characters in assignment ID

### DIFF
--- a/src/main/kotlin/org/dropProject/forms/AssignmentForm.kt
+++ b/src/main/kotlin/org/dropProject/forms/AssignmentForm.kt
@@ -29,6 +29,7 @@ import java.time.LocalDateTime
 import jakarta.validation.constraints.Min
 import jakarta.validation.constraints.NotEmpty
 import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Pattern
 
 /**
  * Enum that represents the submission methods that are available in DP.
@@ -42,6 +43,7 @@ enum class SubmissionMethod {
  */
 data class AssignmentForm(
         @field:NotEmpty(message = "Error: Assignment Id must not be empty")
+        @field:Pattern(regexp = "^[a-zA-Z0-9_-]+$", message = "Error: Assignment Id must only contain letters, numbers, hyphens and underscores")
         var assignmentId: String? = null,
 
         @field:NotEmpty(message = "Error: Assignment Name must not be empty")

--- a/src/test/kotlin/org/dropProject/controllers/AssignmentControllerTests.kt
+++ b/src/test/kotlin/org/dropProject/controllers/AssignmentControllerTests.kt
@@ -2105,12 +2105,11 @@ class AssignmentControllerTests {
             .andExpect(status().isOk())
             .andExpect(view().name("assignment-form"))
             .andExpect(model().attributeHasFieldErrors("assignmentForm", "acl"))
-    }
-
+}
     @Test
     @WithMockUser("teacher1", roles = ["TEACHER"])
     @DirtiesContext
-    fun test_34_createAssignmentWithACLContainingSemicolons() {
+    fun test_33_createAssignmentWithACLContainingSpaces() {
         mvc.perform(
             post("/assignment/new")
                 .param("assignmentId", "assignmentId")
@@ -2119,7 +2118,7 @@ class AssignmentControllerTests {
                 .param("language", "JAVA")
                 .param("submissionMethod", "UPLOAD")
                 .param("gitRepositoryUrl", sampleJavaAssignmentRepo)
-                .param("acl", "teacher2;teacher3")
+                .param("acl", "teacher2 teacher3")
         )
             .andExpect(status().isOk())
             .andExpect(view().name("assignment-form"))

--- a/src/test/kotlin/org/dropProject/controllers/AssignmentControllerTests.kt
+++ b/src/test/kotlin/org/dropProject/controllers/AssignmentControllerTests.kt
@@ -2091,7 +2091,6 @@ class AssignmentControllerTests {
     @WithMockUser("teacher1", roles = ["TEACHER"])
     @DirtiesContext
     fun test_33_createAssignmentWithACLContainingSpaces() {
-
         mvc.perform(
             post("/assignment/new")
                 .param("assignmentId", "assignmentId")
@@ -2101,24 +2100,6 @@ class AssignmentControllerTests {
                 .param("submissionMethod", "UPLOAD")
                 .param("gitRepositoryUrl", sampleJavaAssignmentRepo)
                 .param("acl", "teacher2 teacher3")  // space instead of comma
-        )
-            .andExpect(status().isOk())
-            .andExpect(view().name("assignment-form"))
-            .andExpect(model().attributeHasFieldErrors("assignmentForm", "acl"))
-}
-    @Test
-    @WithMockUser("teacher1", roles = ["TEACHER"])
-    @DirtiesContext
-    fun test_33_createAssignmentWithACLContainingSpaces() {
-        mvc.perform(
-            post("/assignment/new")
-                .param("assignmentId", "assignmentId")
-                .param("assignmentName", "assignmentName")
-                .param("assignmentPackage", "assignmentPackage")
-                .param("language", "JAVA")
-                .param("submissionMethod", "UPLOAD")
-                .param("gitRepositoryUrl", sampleJavaAssignmentRepo)
-                .param("acl", "teacher2 teacher3")
         )
             .andExpect(status().isOk())
             .andExpect(view().name("assignment-form"))

--- a/src/test/kotlin/org/dropProject/controllers/AssignmentControllerTests.kt
+++ b/src/test/kotlin/org/dropProject/controllers/AssignmentControllerTests.kt
@@ -2086,6 +2086,7 @@ class AssignmentControllerTests {
         }
     }
 
+
     @Test
     @WithMockUser("teacher1", roles = ["TEACHER"])
     @DirtiesContext
@@ -2110,7 +2111,6 @@ class AssignmentControllerTests {
     @WithMockUser("teacher1", roles = ["TEACHER"])
     @DirtiesContext
     fun test_34_createAssignmentWithACLContainingSemicolons() {
-
         mvc.perform(
             post("/assignment/new")
                 .param("assignmentId", "assignmentId")
@@ -2119,11 +2119,27 @@ class AssignmentControllerTests {
                 .param("language", "JAVA")
                 .param("submissionMethod", "UPLOAD")
                 .param("gitRepositoryUrl", sampleJavaAssignmentRepo)
-                .param("acl", "teacher2;teacher3")  // semicolon instead of comma
+                .param("acl", "teacher2;teacher3")
         )
             .andExpect(status().isOk())
             .andExpect(view().name("assignment-form"))
             .andExpect(model().attributeHasFieldErrors("assignmentForm", "acl"))
     }
+
+    @Test
+    @WithMockUser("teacher1", roles = ["TEACHER"])
+    @DirtiesContext
+    fun test_assignmentIdWithBackslashIsRejected() {
+        mvc.perform(
+            post("/assignment/new")
+                .param("assignmentId", "test\\assignment")
+                .param("assignmentName", "Test Assignment")
+                .param("language", "JAVA")
+                .param("submissionMethod", "UPLOAD")
+                .param("gitRepositoryUrl", "git@github.com:user/test.git")
+        )
+            .andExpect(status().isOk)
+            .andExpect(view().name("assignment-form"))
+            .andExpect(model().attributeHasFieldErrors("assignmentForm", "assignmentId"))
+    }
 }
-    


### PR DESCRIPTION
Fixes #98

## Problem
When creating an assignment with a backslash (`\`) in the ID field, the application returned an HTTP 404 error instead of a proper validation message.

## Root Cause
The `assignmentId` field in `AssignmentForm.kt` had no pattern validation, so any character was accepted. When a backslash was submitted, the URL routing failed with 404.

## Fix
Added a `@Pattern` annotation to the `assignmentId` field in `AssignmentForm.kt` to only allow letters, numbers, hyphens and underscores:

```kotlin
@field:NotEmpty(message = "Error: Assignment Id must not be empty")
@field:Pattern(regexp = "^[a-zA-Z0-9_-]+$", message = "Error: Assignment Id must only contain letters, numbers, hyphens and underscores")
var assignmentId: String? = null,
```

## Testing
1. Start the application locally
2. Log in as teacher
3. Navigate to Create Assignment
4. Enter `test\assignment` in the ID field and fill the other required fields
5. Click Save — a clear validation error message is now shown instead of a 404 error