### PR TITLE
fix: preserve tag filter after toggling assignment status

### DIFF
--- a/src/main/kotlin/org/dropProject/controllers/AssignmentController.kt
+++ b/src/main/kotlin/org/dropProject/controllers/AssignmentController.kt
@@ -848,8 +848,11 @@ class AssignmentController(
      */
     @RequestMapping(value = ["/toggle-status/{assignmentId}"], method = [(RequestMethod.GET), (RequestMethod.POST)])
     @Transactional  // this is needed since checkAssignmentFiles will insert assignmentTestMethods in the BD
-    fun toggleAssignmentStatus(@PathVariable assignmentId: String, redirectAttributes: RedirectAttributes,
+    fun toggleAssignmentStatus(@PathVariable assignmentId: String,
+                               @RequestParam(name = "tags", required = false) tags: String?,
+                               redirectAttributes: RedirectAttributes,
                                principal: Principal): String {
+        val redirectUrl = if (tags != null) "redirect:/assignment/my?tags=$tags" else "redirect:/assignment/my"
 
         val assignment = assignmentRepository.findById(assignmentId)
             .orElseThrow { EntityNotFoundException("Assignment $assignmentId not found") }
@@ -865,7 +868,7 @@ class AssignmentController(
             // check if it has been setup for git connection and if there is a repository folder
             if (!File(dropProjectProperties.assignments.rootLocation, assignment.gitRepositoryFolder).exists()) {
                 redirectAttributes.addFlashAttribute("error", "Can't mark assignment as active since it is not connected to a git repository.")
-                return "redirect:/assignment/my"
+                return redirectUrl
             }
 
             val report = assignmentTeacherFiles.checkAssignmentFiles(assignment, principal)
@@ -890,7 +893,7 @@ class AssignmentController(
         assignmentRepository.save(assignment)
 
         redirectAttributes.addFlashAttribute("message", "Assignment was marked ${if (assignment.active) "active" else "inactive"}")
-        return "redirect:/assignment/my"
+        return redirectUrl
     }
 
     /**
@@ -1205,6 +1208,7 @@ class AssignmentController(
         model["allTags"] = assignmentTagRepository.findAll()
             .map { it.selected = tags?.split(",")?.contains(it.name) ?: false; it }
             .sortedBy { it.name }
+        model["currentTags"] = tags ?: ""
     }
 
 

--- a/src/main/resources/templates/teacher-assignments-list.html
+++ b/src/main/resources/templates/teacher-assignments-list.html
@@ -55,6 +55,7 @@
             <td th:if="${assignment.lastSubmissionDate == null}">-</td>
             <td th:if="${!archived}" class="text-center" th:data-order="${assignment.active}">
                 <form th:action="@{'/assignment/toggle-status/' + ${assignment.id}}" method="post" style="display: inline;">
+                    <input type="hidden" name="tags" th:value="${currentTags}"/>
                     <input type="checkbox" th:attr="data-assignment-id=${assignment.id}" th:checked="${assignment.active}"
                            onChange="
                             if (this.checked) {

--- a/src/test/kotlin/org/dropProject/controllers/AssignmentControllerTests.kt
+++ b/src/test/kotlin/org/dropProject/controllers/AssignmentControllerTests.kt
@@ -2146,4 +2146,3 @@ class AssignmentControllerTests {
             .andExpect(header().string("Location", "/assignment/my?tags=sample"))
     }
 }
->>>>>>> 465854d (test: add test for tag filter preservation after toggling assignment status (#89))

--- a/src/test/kotlin/org/dropProject/controllers/AssignmentControllerTests.kt
+++ b/src/test/kotlin/org/dropProject/controllers/AssignmentControllerTests.kt
@@ -2090,7 +2090,6 @@ class AssignmentControllerTests {
     @WithMockUser("teacher1", roles = ["TEACHER"])
     @DirtiesContext
     fun test_33_createAssignmentWithACLContainingSpaces() {
-
         mvc.perform(
             post("/assignment/new")
                 .param("assignmentId", "assignmentId")
@@ -2105,12 +2104,10 @@ class AssignmentControllerTests {
             .andExpect(view().name("assignment-form"))
             .andExpect(model().attributeHasFieldErrors("assignmentForm", "acl"))
     }
-
     @Test
     @WithMockUser("teacher1", roles = ["TEACHER"])
     @DirtiesContext
     fun test_34_createAssignmentWithACLContainingSemicolons() {
-
         mvc.perform(
             post("/assignment/new")
                 .param("assignmentId", "assignmentId")
@@ -2125,5 +2122,28 @@ class AssignmentControllerTests {
             .andExpect(view().name("assignment-form"))
             .andExpect(model().attributeHasFieldErrors("assignmentForm", "acl"))
     }
+
+
+@Test
+    @WithMockUser("teacher1", roles = ["TEACHER"])
+    @DirtiesContext
+    fun test_tagFilterPreservedAfterToggle() {
+        val assignment = Assignment(
+            id = "testJavaProj", name = "Test Project (for automatic tests)",
+            packageName = "org.testProj", ownerUserId = "teacher1",
+            submissionMethod = SubmissionMethod.UPLOAD, active = true, gitRepositoryUrl = "git://dummyRepo",
+            gitRepositoryFolder = "testJavaProj"
+        )
+        assignmentRepository.save(assignment)
+
+        // toggle with tags parameter - should redirect preserving the tag
+        this.mvc.perform(
+            post("/assignment/toggle-status/testJavaProj")
+                .param("tags", "sample")
+                .with(user(TEACHER_1))
+        )
+            .andExpect(status().isFound)
+            .andExpect(header().string("Location", "/assignment/my?tags=sample"))
+    }
 }
-    
+>>>>>>> 465854d (test: add test for tag filter preservation after toggling assignment status (#89))

--- a/src/test/kotlin/org/dropProject/controllers/AssignmentControllerTests.kt
+++ b/src/test/kotlin/org/dropProject/controllers/AssignmentControllerTests.kt
@@ -2124,7 +2124,7 @@ class AssignmentControllerTests {
     }
 
 
-@Test
+    @Test
     @WithMockUser("teacher1", roles = ["TEACHER"])
     @DirtiesContext
     fun test_tagFilterPreservedAfterToggle() {


### PR DESCRIPTION
Fixes #89

## Problem
When a tag filter was applied in the Current Assignments page and the teacher toggled the Active? checkbox, the tag filter was lost after the redirect. The page returned to the default state showing all assignments.

## Root Cause
The `toggleAssignmentStatus` controller did not receive or preserve the active tag filter. After toggling, it always redirected to `/assignment/my` without any query parameters, discarding the selected tags.

## Fix
Three changes were made:

**1. `AssignmentController.kt`** — Added `tags` as a `@RequestParam` to `toggleAssignmentStatus` and used a local variable for the redirect:
```kotlin
fun toggleAssignmentStatus(@PathVariable assignmentId: String,
                           @RequestParam(name = "tags", required = false) tags: String?,
                           ...): String {
    val redirectUrl = if (tags != null) "redirect:/assignment/my?tags=$tags" else "redirect:/assignment/my"
    ...
    return redirectUrl
}
```

**2. `AssignmentController.kt`** — Added `currentTags` to the model in `listMyFilteredAssignments`:
```kotlin
model["currentTags"] = tags ?: ""
```

**3. `teacher-assignments-list.html`** — Added a hidden input to pass the current tags when the toggle form is submitted:
```html
<form th:action="@{'/assignment/toggle-status/' + ${assignment.id}}" method="post">
    <input type="hidden" name="tags" th:value="${currentTags}"/>
    ...
</form>
```

## Testing
1. Start the application locally
2. Log in as teacher
3. Navigate to Assignments → Current Assignments
4. Select a tag filter (e.g. `kotlin`) — only filtered assignments are shown
5. Toggle the Active? checkbox of an assignment
6. The tag filter is now preserved after the redirect