### PR TITLE
fix: Unclear error message when AUTHORS.txt is not at the root

### DIFF
--- a/src/main/kotlin/org/dropProject/services/SubmissionService.kt
+++ b/src/main/kotlin/org/dropProject/services/SubmissionService.kt
@@ -235,6 +235,20 @@ class SubmissionService(
         val projectFolder: File? = storageService.store(file, assignment.id)
 
         if (projectFolder != null) {
+
+            val topLevelEntries = projectFolder.listFiles()
+            if (topLevelEntries != null) {
+                val directories = topLevelEntries.filter {
+                    it.isDirectory && !it.name.startsWith("__MACOSX") && !it.name.startsWith(".")
+                }
+                val files = topLevelEntries.filter { it.isFile }
+
+                if (directories.size == 1 && files.all { it.extension.equals("txt", ignoreCase = true) }) {
+                    return ResponseEntity.internalServerError()
+                        .body(SubmissionResult(error = i18n.getMessage("error.zip.wrapped.folder", null, currentLocale)))
+                }
+            }
+
             val authors = getProjectAuthors(File(projectFolder, "AUTHORS.txt"))
             LOG.info("[${authors.joinToString(separator = "|")}] Received ${originalFilename}")
 

--- a/src/main/kotlin/org/dropProject/services/SubmissionService.kt
+++ b/src/main/kotlin/org/dropProject/services/SubmissionService.kt
@@ -241,9 +241,13 @@ class SubmissionService(
                 val directories = topLevelEntries.filter {
                     it.isDirectory && !it.name.startsWith("__MACOSX") && !it.name.startsWith(".")
                 }
-                val files = topLevelEntries.filter { it.isFile }
 
-                if (directories.size == 1 && files.all { it.extension.equals("txt", ignoreCase = true) }) {
+                val hasAuthorsInRoot = File(projectFolder, "AUTHORS.txt").existsCaseSensitive()
+                val hasSingleDirectory = directories.size == 1
+                val hasAuthorsInsideDirectory = hasSingleDirectory &&
+                        File(directories[0], "AUTHORS.txt").existsCaseSensitive()
+
+                if (!hasAuthorsInRoot && hasSingleDirectory && hasAuthorsInsideDirectory) {
                     return ResponseEntity.internalServerError()
                         .body(SubmissionResult(error = i18n.getMessage("error.zip.wrapped.folder", null, currentLocale)))
                 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -88,6 +88,7 @@ error.structure.readme.not.file=The project contains a README.md folder but it s
 error.structure.test.naming=Test classes must start with the word Test (example: TestCar)
 
 # AUTHORS.txt errors
+error.zip.wrapped.folder=Please make sure that AUTHORS.txt is placed directly in the root of the ZIP, and that your ZIP does not contain an extra top-level folder (e.g., project-name/AUTHORS.txt).
 error.authors.missing=The project does not contain the AUTHORS.txt file in the root
 error.authors.number.blank=The student number must be filled in for all group members
 error.authors.format.invalid=Each line must have the format STUDENT_ID;STUDENT_NAME. The student name must include the first and last name.

--- a/src/main/resources/messages_en_US.properties
+++ b/src/main/resources/messages_en_US.properties
@@ -88,6 +88,7 @@ error.structure.readme.not.file=The project contains a README.md folder but it s
 error.structure.test.naming=Test classes must start with the word Test (example: TestCar)
 
 # AUTHORS.txt errors
+error.zip.wrapped.folder=Please make sure that AUTHORS.txt is placed directly in the root of the ZIP, and that your ZIP does not contain an extra top-level folder (e.g., project-name/AUTHORS.txt).
 error.authors.missing=The project does not contain the AUTHORS.txt file in the root
 error.authors.number.blank=The student number must be filled in for all group members
 error.authors.format.invalid=Each line must have the format STUDENT_ID;STUDENT_NAME. The student name must include the first and last name.

--- a/src/main/resources/messages_pt_PT.properties
+++ b/src/main/resources/messages_pt_PT.properties
@@ -88,6 +88,7 @@ error.structure.readme.not.file=O projecto cont√©m uma pasta README.md mas devia
 error.structure.test.naming=As classes de teste devem come√ßar com a palavra Test (exemplo: TestCar)
 
 # AUTHORS.txt errors
+error.zip.wrapped.folder=Certifica-te de que o ficheiro AUTHORS.txt est· colocado diretamente na raiz do ZIP e que o teu ZIP n„o contÈm uma pasta extra no nÌvel superior (por exemplo, project-name/AUTHORS.txt).
 error.authors.missing=O projecto n√£o cont√©m o ficheiro AUTHORS.txt na raiz
 error.authors.number.blank=O n√∫mero de aluno tem que estar preenchido para todos os elementos do grupo
 error.authors.format.invalid=Cada linha tem que ter o formato NUMERO_ALUNO;NOME_ALUNO. O nome do aluno deve incluir o primeiro e √∫ltimo nome.

--- a/src/test/kotlin/org/dropProject/controllers/UploadControllerTests.kt
+++ b/src/test/kotlin/org/dropProject/controllers/UploadControllerTests.kt
@@ -2183,6 +2183,54 @@ class UploadControllerTests {
         assertEquals(Indicator.PROJECT_STRUCTURE, lastSubmission.reportElements!![0].indicator)
         assertEquals("NOK", lastSubmission.reportElements!![0].reportValue)
     }
+
+    @Test
+    @DirtiesContext
+    fun `upload project with nested folder in zip should return error`() {
+
+        // Create a temp folder simulating the wrong zip structure:
+        // outerFolder/
+        //   └── my-project/
+        //       ├── src/
+        //       └── AUTHORS.txt
+        val tempDirectory = File(System.getProperty("java.io.tmpdir"))
+        val zipCreationTime = System.currentTimeMillis()
+
+        val projectFolder = File(tempDirectory, "my-project-$zipCreationTime")
+        projectFolder.mkdir()
+        File(projectFolder, "src").mkdir()
+        File(projectFolder, "AUTHORS.txt").apply {
+            createNewFile()
+            writeText("student1;Student 1")
+        }
+
+        val outerFolder = File(tempDirectory, "outer-$zipCreationTime")
+        outerFolder.mkdir()
+        projectFolder.copyRecursively(File(outerFolder, projectFolder.name))
+
+        // Zip the outer folder (wrong structure)
+        val zipFile = zipService.createZipFromFolder("bad-submission-$zipCreationTime", outerFolder)
+        zipFile.deleteOnExit()
+
+        val multipartFile = MockMultipartFile("file", zipFile.name, "application/zip", zipFile.readBytes())
+
+        this.mvc.perform(
+            multipart("/upload")
+                .file(multipartFile)
+                .param("assignmentId", "testJavaProj")
+                .param("async", "false")
+                .with(user(STUDENT_1))
+        )
+            .andExpect(status().isInternalServerError)
+            .andExpect(content().string(
+                """{"error":"Please make sure that AUTHORS.txt is placed directly in the root of the ZIP, and that your ZIP does not contain an extra top-level folder (e.g., project-name/AUTHORS.txt)."}"""
+            ))
+
+        // clean-up
+        projectFolder.deleteRecursively()
+        outerFolder.deleteRecursively()
+        zipFile.delete()
+    }
 }
 
 


### PR DESCRIPTION

### What is the current behavior?
When a student submits a ZIP file that contains a folder instead of the project contents directly (i.e., they zipped the project folder itself rather than its contents), the system would attempt to process the submission normally and fail with a confusing AUTHORS.txt not found error, giving no clear indication of what went wrong.

### What is the new behavior?
The system now detects this invalid ZIP structure early in the submission process (right after extracting the ZIP) and immediately returns a clear error message to the student, explaining that they zipped the project folder instead of its contents. The detection also correctly handles macOS-generated __MACOSX metadata folders, which would otherwise cause false negatives.

### Issue
This change is related to the following issue: #101

### How to test
1. Login as a student
2. Go to sampleJavaProject
3. Submit this [file](https://github.com/user-attachments/files/27123020/sampleJavaSubmission_withAuthorsNotInTheRoot.zip), this file have this structure:
 
```
project/
    -src/
       -(Java files...)
    AUTHORS.txt   
```
   
5. It should appear a new error mensagem like this one:
<img width="1388" height="672" alt="Captura de ecrã 2026-04-27, às 12 05 06" src="https://github.com/user-attachments/assets/4e3823c5-77ca-4a5c-88c7-b8e98c25b40c" />

