### PR TITLE
fix: allow teachers to bypass group restrictions on submissions

### DIFF
--- a/src/main/kotlin/org/dropProject/services/SubmissionService.kt
+++ b/src/main/kotlin/org/dropProject/services/SubmissionService.kt
@@ -248,7 +248,7 @@ class SubmissionService(
             if (assignment.projectGroupRestrictions != null) {
                 val restrictions = assignment.projectGroupRestrictions!!
                 if (authors.size !in restrictions.minGroupSize .. (restrictions.maxGroupSize ?: 50) &&
-                    !restrictions.exceptionsAsList().contains(principal.realName())) {
+                    !restrictions.exceptionsAsList().contains(principal.realName())) && !request.isUserInRole("TEACHER") {
                     throw InvalidProjectGroupException(i18n.getMessage("student.submit.invalidGroup",
                         arrayOf(restrictions.minGroupSize, restrictions.maxGroupSize ?: 50), currentLocale))
                 }

--- a/src/main/kotlin/org/dropProject/services/SubmissionService.kt
+++ b/src/main/kotlin/org/dropProject/services/SubmissionService.kt
@@ -248,7 +248,7 @@ class SubmissionService(
             if (assignment.projectGroupRestrictions != null) {
                 val restrictions = assignment.projectGroupRestrictions!!
                 if (authors.size !in restrictions.minGroupSize .. (restrictions.maxGroupSize ?: 50) &&
-                    !restrictions.exceptionsAsList().contains(principal.realName())) && !request.isUserInRole("TEACHER") {
+                    !restrictions.exceptionsAsList().contains(principal.realName()) && !request.isUserInRole("TEACHER")) {
                     throw InvalidProjectGroupException(i18n.getMessage("student.submit.invalidGroup",
                         arrayOf(restrictions.minGroupSize, restrictions.maxGroupSize ?: 50), currentLocale))
                 }

--- a/src/test/kotlin/org/dropProject/controllers/UploadControllerTests.kt
+++ b/src/test/kotlin/org/dropProject/controllers/UploadControllerTests.kt
@@ -1705,6 +1705,21 @@ class UploadControllerTests {
 
     @Test
     @DirtiesContext
+    fun `upload group project as teacher`() {
+
+        val projectGroupRestrictions = ProjectGroupRestrictions(minGroupSize = 2, maxGroupSize = 2)
+        projectGroupRestrictionsRepository.save(projectGroupRestrictions)
+
+        val assignment = assignmentRepository.findById("testJavaProj").get()
+        assignment.projectGroupRestrictions = projectGroupRestrictions
+        assignmentRepository.save(assignment)
+
+        testsHelper.uploadProject(this.mvc, "projectOKTeacher", "testJavaProj", TEACHER_1,
+            expectedResultMatcher = status().isOk())
+    }
+
+    @Test
+    @DirtiesContext
     fun `upload a project with test classes that dont follow the TestXXX convention should show an error`() {
 
         val submissionId = testsHelper.uploadProject(this.mvc, "projectWithStudentTestNotValid", "testJavaProj", STUDENT_1)

--- a/src/test/sampleProjects/compact/java/projectOKTeacher/AUTHORS.txt
+++ b/src/test/sampleProjects/compact/java/projectOKTeacher/AUTHORS.txt
@@ -1,0 +1,1 @@
+teacher1;teacher 1

--- a/src/test/sampleProjects/compact/java/projectOKTeacher/src/org/dropProject/sampleAssignments/testProj/Main.java
+++ b/src/test/sampleProjects/compact/java/projectOKTeacher/src/org/dropProject/sampleAssignments/testProj/Main.java
@@ -1,0 +1,25 @@
+package org.dropProject.sampleAssignments.testProj;
+
+public class Main {
+
+    static int funcaoParaTestar() {
+        return 3;
+    }
+
+    static int funcaoQueRebenta() {
+        return 3;
+    }
+
+    static int funcaoLentaParaTestar() {
+        try {
+            Thread.sleep(5000);
+        } catch (Exception ignore) {
+            // ignore
+        }
+        return 3;
+    }
+
+    public static void main(String[] args) {
+        System.out.println("Sample!");
+    }
+}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?
<!-- List issue if it fixes/closes/implements one using the "Fixes #<number>" or "Closes #<number>" syntax -->
fixes #90 require teachers to be in a group when submitting a project

### What is the new behavior?
teacher can submit a project  without being in a group

### Other information?
Manual tests:  
- Attempt to submit as a teacher  
- Attempt to submit as a student  
- Attempt to submit as a student in groups  

New unit test:  
- Attempt to submit as a teacher alone
