### PR TITLE
Fix teacher submission blocked by assignment whitelist

### DIFF
--- a/src/main/kotlin/org/dropProject/controllers/UploadController.kt
+++ b/src/main/kotlin/org/dropProject/controllers/UploadController.kt
@@ -183,11 +183,14 @@ class UploadController(
         val assignment = assignmentRepository.findById(assignmentId)
             .orElseThrow { throw ResponseStatusException(HttpStatus.NOT_FOUND, "Assignment not found") }
 
+        val isTeacher = request.isUserInRole("TEACHER")
+        val isAuthorizedTeacher = assignmentService.isAuthorizedTeacher(assignmentId, principal.realName())
         // Check authorization (403 if unauthorized)
-        if (!authorizationService.canAccessAssignment(assignmentId, principal.realName(), request.isUserInRole("TEACHER"))) {
+        if (!authorizationService.canAccessAssignment(assignmentId, principal.realName(), isTeacher || isAuthorizedTeacher)) {
             throw AccessDeniedException("User ${principal.realName()} is not authorized to access assignment $assignmentId")
         }
 
+        model["isTeacher"] = isTeacher
         model["assignment"] = assignment
         model["numSubmissions"] = submissionRepository.countBySubmitterUserIdAndAssignmentId(principal.realName(), assignment.id)
         model["instructionsFragment"] = assignmentTeacherFiles.getInstructions(assignment).body //quick fix
@@ -195,7 +198,7 @@ class UploadController(
                 assignment.packageName, assignment.language,
                 assignment.submissionStructure, assignment.acceptsStudentTests)
 
-        if (assignment.cooloffPeriod != null && !request.isUserInRole("TEACHER")) {
+        if (assignment.cooloffPeriod != null && !isAuthorizedTeacher) {
             val lastSubmission = submissionService.getLastSubmission(principal, assignmentId)
             if (lastSubmission != null) {
                 val nextSubmissionTime = submissionService.calculateCoolOff(lastSubmission, assignment)
@@ -611,12 +614,13 @@ class UploadController(
         val gitSubmission = gitSubmissionRepository.findById(gitSubmissionId.toLong()).orElse(null) ?: throw SubmissionNotFoundException(gitSubmissionId.toLong())
         val assignment = assignmentRepository.findById(gitSubmission.assignmentId).orElse(null)
         
+        val isAuthorizedTeacher = assignmentService.isAuthorizedTeacher(assignment.id, principal.realName())
         // Check authorization (403 if unauthorized)  
-        if (!authorizationService.canAccessAssignmentByGitSubmissionId(gitSubmissionId, principal.realName(), request.isUserInRole("TEACHER"))) {
+        if (!authorizationService.canAccessAssignmentByGitSubmissionId(gitSubmissionId, principal.realName(), isAuthorizedTeacher)) {
             throw AccessDeniedException("User ${principal.realName()} is not authorized to access git submission $gitSubmissionId")
         }
 
-        if (assignment.cooloffPeriod != null && !request.isUserInRole("TEACHER")) {
+        if (assignment.cooloffPeriod != null && !isAuthorizedTeacher) {
             val lastSubmission = submissionService.getLastSubmission(principal, assignment.id)
             if (lastSubmission != null) {
                 val nextSubmissionTime = submissionService.calculateCoolOff(lastSubmission, assignment)

--- a/src/main/kotlin/org/dropProject/controllers/UploadController.kt
+++ b/src/main/kotlin/org/dropProject/controllers/UploadController.kt
@@ -183,14 +183,13 @@ class UploadController(
         val assignment = assignmentRepository.findById(assignmentId)
             .orElseThrow { throw ResponseStatusException(HttpStatus.NOT_FOUND, "Assignment not found") }
 
-        val isTeacher = request.isUserInRole("TEACHER")
-        val isAuthorizedTeacher = assignmentService.isAuthorizedTeacher(assignmentId, principal.realName())
+        val isAuthorizedTeacher = request.isUserInRole("TEACHER") &&
+                assignmentService.isAuthorizedTeacher(assignment, principal.realName(), request)
         // Check authorization (403 if unauthorized)
-        if (!authorizationService.canAccessAssignment(assignmentId, principal.realName(), isTeacher || isAuthorizedTeacher)) {
+        if (!authorizationService.canAccessAssignment(assignmentId, principal.realName(),isAuthorizedTeacher)) {
             throw AccessDeniedException("User ${principal.realName()} is not authorized to access assignment $assignmentId")
         }
 
-        model["isTeacher"] = isTeacher
         model["assignment"] = assignment
         model["numSubmissions"] = submissionRepository.countBySubmitterUserIdAndAssignmentId(principal.realName(), assignment.id)
         model["instructionsFragment"] = assignmentTeacherFiles.getInstructions(assignment).body //quick fix
@@ -613,9 +612,11 @@ class UploadController(
         // Check if git submission exists first (404 if not)
         val gitSubmission = gitSubmissionRepository.findById(gitSubmissionId.toLong()).orElse(null) ?: throw SubmissionNotFoundException(gitSubmissionId.toLong())
         val assignment = assignmentRepository.findById(gitSubmission.assignmentId).orElse(null)
-        
-        val isAuthorizedTeacher = assignmentService.isAuthorizedTeacher(assignment.id, principal.realName())
-        // Check authorization (403 if unauthorized)  
+
+        val isAuthorizedTeacher = request.isUserInRole("TEACHER") &&
+                assignmentService.isAuthorizedTeacher(assignment, principal.realName(), request)
+
+        // Check authorization (403 if unauthorized)
         if (!authorizationService.canAccessAssignmentByGitSubmissionId(gitSubmissionId, principal.realName(), isAuthorizedTeacher)) {
             throw AccessDeniedException("User ${principal.realName()} is not authorized to access git submission $gitSubmissionId")
         }

--- a/src/main/kotlin/org/dropProject/services/AssignmentService.kt
+++ b/src/main/kotlin/org/dropProject/services/AssignmentService.kt
@@ -787,10 +787,10 @@ class AssignmentService(
 
     }
 
-    fun isAuthorizedTeacher(assignmentId: String, principalName: String): Boolean {
-        val assignment = assignmentRepository.findByIdOrNull(assignmentId)
-        return assignment != null && (assignment.ownerUserId == principalName ||
-                assignmentACLRepository.existsByAssignmentIdAndUserId(assignmentId, principalName))
+    fun isAuthorizedTeacher(assignment: Assignment, principalName: String, request: HttpServletRequest): Boolean {
+        return request.isUserInRole("TEACHER") &&
+                (assignment.ownerUserId == principalName ||
+                        assignmentACLRepository.existsByAssignmentIdAndUserId(assignment.id, principalName))
     }
 
     /**
@@ -802,9 +802,6 @@ class AssignmentService(
      * @throws If the user is not allowed to access the Assignment, an [AccessDeniedException] will be thrown.
      */
     fun checkAssignees(assignmentId: String, principalName: String) {
-        if (isAuthorizedTeacher(assignmentId, principalName)) {
-            return
-        }
 
         if (assigneeRepository.existsByAssignmentId(assignmentId)) {
             // if it enters here, it means this assignment has a white list

--- a/src/main/kotlin/org/dropProject/services/AssignmentService.kt
+++ b/src/main/kotlin/org/dropProject/services/AssignmentService.kt
@@ -787,6 +787,12 @@ class AssignmentService(
 
     }
 
+    fun isAuthorizedTeacher(assignmentId: String, principalName: String): Boolean {
+        val assignment = assignmentRepository.findByIdOrNull(assignmentId)
+        return assignment != null && (assignment.ownerUserId == principalName ||
+                assignmentACLRepository.existsByAssignmentIdAndUserId(assignmentId, principalName))
+    }
+
     /**
      * Checks if a certain user can access a certain [Assignment]. Only relevant for Assignments that have access
      * control lists.
@@ -796,6 +802,10 @@ class AssignmentService(
      * @throws If the user is not allowed to access the Assignment, an [AccessDeniedException] will be thrown.
      */
     fun checkAssignees(assignmentId: String, principalName: String) {
+        if (isAuthorizedTeacher(assignmentId, principalName)) {
+            return
+        }
+
         if (assigneeRepository.existsByAssignmentId(assignmentId)) {
             // if it enters here, it means this assignment has a white list
             // let's check if the current user belongs to the white list
@@ -811,11 +821,17 @@ class AssignmentService(
      * @param groupMembers is a List of author IDs (student numbers) representing the group members
      * @param i18n is the MessageSource for internationalization
      * @param currentLocale is the current Locale for message formatting
+     * @param isTeacher is a Boolean indicating if the submitter is a teacher
      * @throws InvalidProjectGroupException if any group member is not in the whitelist
      */
     fun checkGroupMembersInWhitelist(assignmentId: String, groupMembers: List<String>,
                                      i18n: org.springframework.context.MessageSource,
-                                     currentLocale: java.util.Locale) {
+                                     currentLocale: java.util.Locale,
+                                     isTeacher: Boolean = false) {
+        if (isTeacher) {
+            return
+        }
+
         if (assigneeRepository.existsByAssignmentId(assignmentId)) {
             // if it enters here, it means this assignment has a white list
             // let's check if all group members belong to the white list

--- a/src/main/kotlin/org/dropProject/services/SubmissionService.kt
+++ b/src/main/kotlin/org/dropProject/services/SubmissionService.kt
@@ -201,9 +201,12 @@ class SubmissionService(
             throw IllegalArgumentException("API submissions are not supported for Maven-structured assignments. Please use the web interface.")
         }
 
+        val isAuthorizedTeacher = assignmentService.isAuthorizedTeacher(assignment.id, principal.realName())
+        val isTeacher = request.isUserInRole("TEACHER") || isAuthorizedTeacher
+
         // TODO: Validate assignment due date
 
-        if (!request.isUserInRole("TEACHER")) {
+        if (!isAuthorizedTeacher) {
 
             if (!assignment.active) {
                 throw AccessDeniedException("Submissions are not open to this assignment")
@@ -212,7 +215,7 @@ class SubmissionService(
             assignmentService.checkAssignees(uploadForm.assignmentId!!, principal.realName())
         }
 
-        if (assignment.cooloffPeriod != null && !request.isUserInRole("TEACHER")) {
+        if (assignment.cooloffPeriod != null && !isAuthorizedTeacher) {
             val lastSubmission = getLastSubmission(principal, assignment.id)
             if (lastSubmission != null) {
                 val nextSubmissionTime = calculateCoolOff(lastSubmission, assignment)
@@ -255,7 +258,7 @@ class SubmissionService(
             }
 
             // check if all group members are in the assignment's whitelist
-            assignmentService.checkGroupMembersInWhitelist(assignment.id, authors.map { it.number }, i18n, currentLocale)
+            assignmentService.checkGroupMembersInWhitelist(assignment.id, authors.map { it.number }, i18n, currentLocale, isTeacher)
 
             val group = projectGroupService.getOrCreateProjectGroup(authors)
 

--- a/src/main/kotlin/org/dropProject/services/SubmissionService.kt
+++ b/src/main/kotlin/org/dropProject/services/SubmissionService.kt
@@ -201,8 +201,8 @@ class SubmissionService(
             throw IllegalArgumentException("API submissions are not supported for Maven-structured assignments. Please use the web interface.")
         }
 
-        val isAuthorizedTeacher = assignmentService.isAuthorizedTeacher(assignment.id, principal.realName())
-        val isTeacher = request.isUserInRole("TEACHER") || isAuthorizedTeacher
+        val isAuthorizedTeacher = request.isUserInRole("TEACHER") &&
+                assignmentService.isAuthorizedTeacher(assignment, principal.realName(), request)
 
         // TODO: Validate assignment due date
 
@@ -276,7 +276,7 @@ class SubmissionService(
             }
 
             // check if all group members are in the assignment's whitelist
-            assignmentService.checkGroupMembersInWhitelist(assignment.id, authors.map { it.number }, i18n, currentLocale, isTeacher)
+            assignmentService.checkGroupMembersInWhitelist(assignment.id, authors.map { it.number }, i18n, currentLocale, isAuthorizedTeacher)
 
             val group = projectGroupService.getOrCreateProjectGroup(authors)
 

--- a/src/main/resources/templates/leaderboard.html
+++ b/src/main/resources/templates/leaderboard.html
@@ -51,7 +51,7 @@
 
             <td th:if="${!isTeacher}" th:text="${submission.group.id}"></td>
             <td th:if="${isTeacher}">
-                <a th:href="@{/submissions/(assignmentId=${submission.assignmentId},groupId=${submission.group.id})}"
+                <a th:href="@{/submissions(assignmentId=${submission.assignmentId},groupId=${submission.group.id})}"
                    th:text="${submission.group.id}" th:title="${submission.group.authorsNameStr()}"></a>
             </td>
 

--- a/src/test/kotlin/org/dropProject/controllers/UploadControllerTests.kt
+++ b/src/test/kotlin/org/dropProject/controllers/UploadControllerTests.kt
@@ -62,6 +62,7 @@ import org.springframework.test.context.junit4.SpringRunner
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
 import java.io.File
 import java.nio.file.Files
@@ -95,6 +96,9 @@ class UploadControllerTests {
     lateinit var jUnitReportRepository: JUnitReportRepository
 
     @Autowired
+    lateinit var assignmentACLRepository: AssignmentACLRepository
+
+    @Autowired
     lateinit var assignmentRepository: AssignmentRepository
 
     @Autowired
@@ -122,6 +126,7 @@ class UploadControllerTests {
     val STUDENT_2 = User("student2", "", mutableListOf(SimpleGrantedAuthority("ROLE_STUDENT")))
     val STUDENT_3 = User("student3", "", mutableListOf(SimpleGrantedAuthority("ROLE_STUDENT")))
     val TEACHER_1 = User("teacher1", "", mutableListOf(SimpleGrantedAuthority("ROLE_TEACHER")))
+    val TEACHER_2 = User("teacher2", "", mutableListOf(SimpleGrantedAuthority("ROLE_TEACHER")))
 
     @Before
     fun setup() {
@@ -2183,6 +2188,122 @@ class UploadControllerTests {
         assertEquals(Indicator.PROJECT_STRUCTURE, lastSubmission.reportElements!![0].indicator)
         assertEquals("NOK", lastSubmission.reportElements!![0].reportValue)
     }
+
+    @Test
+    @DirtiesContext
+    fun `teacher can submit to private assignment with whitelist`() {
+
+        // 1. Vai buscar o assignment 'testJavaProj' (dono é teacher1)
+        val assignment = assignmentRepository.findById("testJavaProj").get()
+        assignment.visibility = AssignmentVisibility.PRIVATE   // Define como privadopo
+        assignmentRepository.save(assignment)
+
+        // 2. Adiciona o student1 à whitelist
+        assigneeRepository.save(
+            Assignee(
+                assignmentId = "testJavaProj",
+                authorUserId = "student1"
+            )
+        )
+
+        // 3. Tenta submeter como teacher1 (que é o dono mas NÃO está na whitelist)
+        val submissionId = testsHelper.uploadProject(
+            this.mvc,
+            "projectOK",
+            "testJavaProj",
+            TEACHER_1,
+            authors = listOf("teacher1" to "Teacher 1")
+        )
+
+        // 4. Verifica se obteve um ID de submissão válido (sucesso)
+        try {
+            submissionId.toLong()
+        } catch (e: Exception) {
+            fail("Deveria ter conseguido submeter, mas deu erro: $submissionId")
+        }
+
+    }
+
+
+    @Test
+    @DirtiesContext
+    fun `teacher2 cannot submit to private assignment without whitelist or authorized people`() {
+
+        // 1. Tornar o assignment privado
+        val assignment = assignmentRepository.findById("testJavaProj").get()
+        assignment.visibility = AssignmentVisibility.PRIVATE
+        assignmentRepository.save(assignment)
+
+        // 2. Adicionar apenas student1 à whitelist
+        assigneeRepository.save(
+            Assignee(
+                assignmentId = "testJavaProj",
+                authorUserId = "student1"
+            )
+        )
+        // 3. Tentar submeter → deve falhar com 403 Forbidden
+        // Como o GlobalExceptionHandler retorna uma String simples (não JSON) no 403, 
+        // o uploadProject vai lançar uma exceção ao tentar fazer o parse do JSON.
+        try {
+            testsHelper.uploadProject(
+                this.mvc,
+                "projectOK",
+                "testJavaProj",
+                TEACHER_2,
+                authors = listOf("teacher2" to "Teacher 2"),
+                expectedResultMatcher = status().isForbidden
+            )
+            fail("Deveria ter lançado uma exceção de parsing pois a resposta 403 não é JSON")
+        } catch (e: Exception) {
+
+        }
+    }
+
+    @Test
+    @DirtiesContext
+    fun `teacher2 can submit to private assignment when in authorized people but not in whitelist`() {
+
+        // 1. Tornar o assignment privado
+        val assignment = assignmentRepository.findById("testJavaProj").get()
+        assignment.visibility = AssignmentVisibility.PRIVATE
+        assignmentRepository.save(assignment)
+
+        // 2. Adicionar apenas student1 à whitelist
+        assigneeRepository.save(
+            Assignee(
+                assignmentId = "testJavaProj",
+                authorUserId = "student1"
+            )
+        )
+
+        // 3. Adicionar teacher2 à ACL (Lista de professores autorizados)
+        assignmentACLRepository.save(
+            AssignmentACL(
+                assignmentId = "testJavaProj",
+                userId = "teacher2"
+            )
+        )
+
+        // 4. Tentar submeter → deve ter sucesso
+        val submissionId = testsHelper.uploadProject(
+            this.mvc,
+            "projectOK",
+            "testJavaProj",
+            TEACHER_2,
+            authors = listOf("teacher2" to "Teacher 2")
+        )
+
+        // 5. Verifica se obteve um ID de submissão válido
+        try {
+            submissionId.toLong()
+        } catch (e: Exception) {
+            fail("Deveria ter conseguido submeter (está na ACL), mas deu erro: $submissionId")
+        }
+
+        val submissionDB = submissionRepository.findById(submissionId.toLong()).get()
+        assertEquals("teacher2", submissionDB.submitterUserId)
+    }
+
 }
 
 


### PR DESCRIPTION
# Pull Request: Fix Teacher Submission for Assignments with Whitelists (Issue #91)

## Description
This PR fixes **Issue #91: Teachers can't submit when there's a whitelist linked to an assignment**. 

Previously, if an assignment was set to "Private" with a whitelist of students, even the teacher who owned the assignment was blocked from making submissions because they weren't in that student whitelist. 

The fix ensures that "Authorized Teachers" (the owner of the assignment or teachers in the Access Control List) can always bypass submission restrictions (whitelist), while maintaining these restrictions for other users (including other non-authorized teachers).

### Key Changes
- **`SubmissionService.kt`**: 
    - Introduced a clear distinction between a user having the global `TEACHER` role and being an `isAuthorizedTeacher` for a specific assignment.
    - Updated the submission flow to skip `checkAssignees` and `checkGroupMembersInWhitelist` if the user is an authorized teacher.
- **`UploadController.kt`**: 
    - Updated the authorization logic for both web and git-based uploads to ensure teachers authorized for an assignment can access the submission forms and processes even if a whitelist is present.
- **`AssignmentService.kt` Integration**:
    - Leveraged `isAuthorizedTeacher` to correctly grant bypass permissions only to those with administrative rights over the assignment.

## Unit Tests
Three test cases in `UploadControllerTests.kt` validate this fix:
1. **`teacher can submit to private assignment with whitelist`**: Directly addresses Issue #91. It confirms that the assignment owner can submit successfully even if they are not in the student whitelist.
2. **`teacher2 cannot submit to private assignment without whitelist`**: Ensures that a teacher who is NOT authorized for the assignment is still blocked by the whitelist (treated as a student for submission purposes).
3. **`teacher2 can submit to private assignment when in ACL but not in whitelist`**: Confirms that adding a teacher to the Authorized List (ACL) correctly grants them submission privileges, bypassing the student whitelist.
