### PR TITLE
109 teacher download retrieves latest commit instead of selected submission version

### DIFF
--- a/src/main/kotlin/org/dropProject/controllers/ReportController.kt
+++ b/src/main/kotlin/org/dropProject/controllers/ReportController.kt
@@ -32,6 +32,7 @@ import org.dropproject.forms.SubmissionMethod
 import org.dropproject.repository.*
 import org.dropproject.services.*
 import org.dropproject.storage.StorageService
+import org.eclipse.jgit.api.Git
 import org.slf4j.LoggerFactory
 import org.dropproject.config.DropProjectProperties
 import org.springframework.beans.factory.annotation.Value
@@ -271,18 +272,31 @@ class ReportController(
                 if (zFile.exists()) {
                     zFile.delete();
                 }
-                val zipFile = ZipFile(zFile)
-                val zipParameters = ZipParameters()
-                zipParameters.isIncludeRootFolder = false
-                zipParameters.compressionLevel = CompressionLevel.ULTRA
-                zipFile.addFolder(repositoryFolder, zipParameters)
-//                zipFile.createZipFileFromFolder(repositoryFolder, zipParameters, false, -1)
 
-                LOG.info("Created ${zipFile.file.absolutePath}")
+                val hash = reportService.submissionGitInfoRepository.getBySubmissionId(submission.id)?.gitCommitHash
+                val git = Git.open(repositoryFolder)
+                val currentBranch = git.repository.branch
+                try {
+                    if (hash != null) {
+                        git.checkout().setName(hash).call()
+                    }
 
-                response.setHeader("Content-Disposition", "attachment; filename=${zipFilename}.zip")
+                    val zipFile = ZipFile(zFile.absolutePath)
+                    val zipParameters = ZipParameters()
+                    zipParameters.isIncludeRootFolder = false
+                    zipParameters.compressionLevel = CompressionLevel.ULTRA
+                    zipFile.addFolder(repositoryFolder, zipParameters)
 
-                return FileSystemResource(zipFile.file)
+                    LOG.info("Created ${zipFile.file.absolutePath}")
+
+                    response.setHeader("Content-Disposition", "attachment; filename=${zipFilename}.zip")
+
+                    return FileSystemResource(zipFile.file)
+                } finally {
+                    if (hash != null) {
+                        git.checkout().setName(currentBranch).call()
+                    }
+                }
             }
 
         } else {

--- a/src/main/resources/templates/leaderboard.html
+++ b/src/main/resources/templates/leaderboard.html
@@ -51,7 +51,7 @@
 
             <td th:if="${!isTeacher}" th:text="${submission.group.id}"></td>
             <td th:if="${isTeacher}">
-                <a th:href="@{/submissions/(assignmentId=${submission.assignmentId},groupId=${submission.group.id})}"
+                <a th:href="@{/submissions(assignmentId=${submission.assignmentId},groupId=${submission.group.id})}"
                    th:text="${submission.group.id}" th:title="${submission.group.authorsNameStr()}"></a>
             </td>
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

- [ ] Tests for the changes have been added/updated (if possible)
- [ ] Documentation has been updated/added if relevant
- [ ] Screenshots are attached to Github PR if visual/UI changes were made

---

### What is the current behavior?

Fixes [#109](https://github.com/drop-project-edu/drop-project/issues/109)

Currently, ZIP downloads for Git submissions are generated directly from the repository’s current working state.  
This means that if the repository changes after a submission is made, the downloaded ZIP may not correspond to the exact version originally submitted by the student.

As a result:

- downloaded files may include newer commits or changes;
- the exported submission may differ from the evaluated submission;
- repository state inconsistencies can occur.

---

### What is the new behavior?

The ZIP export process now guarantees that the downloaded files match the exact commit associated with the submission.

The implementation now:

- retrieves the stored commit hash for the submission;
- opens the repository using JGit;
- temporarily checks out the corresponding commit;
- generates the ZIP from that commit state;
- restores the repository to its original branch afterwards using a `try/finally` block.

This ensures deterministic and consistent submission exports.

---

### Other information?

This is not a breaking change.

#### How was this tested?

- Verified that ZIP exports now contain the exact files from the submission commit;
- Tested repositories with commits made after the submission to confirm that newer changes are no longer included;
- Confirmed that the repository branch/state is restored correctly after ZIP generation.
