### PR TITLE
Feature/preauthorize assignment acl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -411,6 +411,7 @@
 				<configuration>
 					<args>
 						<arg>-Xjsr305=strict</arg>
+						<arg>-java-parameters</arg>
 					</args>
 					<compilerPlugins>
 						<plugin>spring</plugin>

--- a/src/main/kotlin/org/dropProject/controllers/AdminController.kt
+++ b/src/main/kotlin/org/dropProject/controllers/AdminController.kt
@@ -61,6 +61,19 @@ class AdminController(val mavenInvoker: MavenInvoker,
     val LOG = LoggerFactory.getLogger(this.javaClass.name)
 
     /**
+     * Controller to handle HTTP GET requests for the admin assignments list page.
+     * Shows all non-archived assignments across all users.
+     * @param model is a [ModelMap] that will be populated with information to use in a View
+     * @return A String with the name of the relevant View
+     */
+    @RequestMapping(value = ["/assignments"], method = [(RequestMethod.GET)])
+    fun listAllAssignments(model: ModelMap): String {
+        model["assignments"] = assignmentRepository.findAllByArchivedFalseOrderById()
+        model["allTags"] = assignmentTagRepository.findAll().sortedBy { it.name }
+        return "admin-assignments-list"
+    }
+
+    /**
      * Controller to handle HTTP GET requests related with the admin dashboard.
      * @param modelMap is a [ModelMap] that will be populated with the information to use in a View
      * @return A String with the name of the relevant View

--- a/src/main/kotlin/org/dropProject/controllers/AdminController.kt
+++ b/src/main/kotlin/org/dropProject/controllers/AdminController.kt
@@ -69,7 +69,6 @@ class AdminController(val mavenInvoker: MavenInvoker,
     @RequestMapping(value = ["/assignments"], method = [(RequestMethod.GET)])
     fun listAllAssignments(model: ModelMap): String {
         model["assignments"] = assignmentRepository.findAllByArchivedFalseOrderById()
-        model["allTags"] = assignmentTagRepository.findAll().sortedBy { it.name }
         return "admin-assignments-list"
     }
 

--- a/src/main/kotlin/org/dropProject/controllers/AssignmentController.kt
+++ b/src/main/kotlin/org/dropProject/controllers/AssignmentController.kt
@@ -36,6 +36,7 @@ import org.dropproject.extensions.realName
 import org.dropproject.forms.AssignmentForm
 import org.dropproject.forms.SubmissionMethod
 import org.dropproject.repository.*
+import org.dropproject.security.RequiresAssignmentOwnerOrACL
 import org.dropproject.services.*
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.api.errors.RefNotAdvertisedException
@@ -383,6 +384,7 @@ class AssignmentController(
      *
      * @return a String with the name of the relevant View
      */
+    @RequiresAssignmentOwnerOrACL
     @RequestMapping(value = ["/info/{assignmentId}"], method = [(RequestMethod.GET)])
     fun getAssignmentDetail(@PathVariable assignmentId: String, model: ModelMap, principal: Principal, request: HttpServletRequest): String {
 
@@ -429,6 +431,7 @@ class AssignmentController(
      *
      * @return a String with the name of the relevant View
      */
+    @RequiresAssignmentOwnerOrACL
     @RequestMapping(value = ["/edit/{assignmentId}"], method = [(RequestMethod.GET)])
     @Transactional(readOnly = true)  // because of assignment.tags
     fun getEditAssignmentForm(@PathVariable assignmentId: String, model: ModelMap, principal: Principal): String {
@@ -437,10 +440,6 @@ class AssignmentController(
             .orElseThrow { EntityNotFoundException("Assignment $assignmentId not found") }
 
         val acl = assignmentACLRepository.findByAssignmentId(assignmentId)
-
-        if (principal.realName() != assignment.ownerUserId && acl.find { it -> it.userId == principal.realName() } == null) {
-            throw IllegalAccessException("Assignments can only be changed by their owner or authorized teachers")
-        }
 
         val assignmentForm = createAssignmentFormBasedOnAssignment(assignment, acl)
 
@@ -510,6 +509,7 @@ class AssignmentController(
      *
      * @return a ResponseEntity<String>
      */
+    @RequiresAssignmentOwnerOrACL
     @RequestMapping(value = ["/refresh-git/{assignmentId}"], method = [(RequestMethod.POST)])
     fun refreshAssignmentGitRepository(@PathVariable assignmentId: String,
                                        principal: Principal): ResponseEntity<String> {
@@ -517,12 +517,6 @@ class AssignmentController(
         // check that it exists
         val assignment = assignmentRepository.findById(assignmentId)
             .orElseThrow { EntityNotFoundException("Assignment $assignmentId not found") }
-
-        val acl = assignmentACLRepository.findByAssignmentId(assignmentId)
-
-        if (principal.realName() != assignment.ownerUserId && acl.find { it -> it.userId == principal.realName() } == null) {
-            throw IllegalAccessException("Assignments can only be refreshed by their owner or authorized teachers")
-        }
 
         if (assignment.gitRepositoryPrivKey == null) {
             LOG.warn("Unable to pull git repository for ${assignmentId} because private key is null")
@@ -580,6 +574,7 @@ class AssignmentController(
      *
      * @return a String with the name of the relevant View
      */
+    @RequiresAssignmentOwnerOrACL
     @RequestMapping(value = ["/setup-git/{assignmentId}"], method = [(RequestMethod.GET)])
     fun setupAssignmentToGitRepository(@PathVariable assignmentId: String,
                                        @RequestParam(name = "reconnect", required = false) reconnect: Boolean = false,
@@ -587,12 +582,6 @@ class AssignmentController(
 
         val assignment = assignmentRepository.findById(assignmentId)
             .orElseThrow { EntityNotFoundException("Assignment $assignmentId not found") }
-
-        val acl = assignmentACLRepository.findByAssignmentId(assignmentId)
-
-        if (principal.realName() != assignment.ownerUserId && acl.find { it -> it.userId == principal.realName() } == null) {
-            throw IllegalAccessException("Assignments can only be changed by their owner or authorized teachers")
-        }
 
         if (reconnect) {
             // clear git keys
@@ -629,6 +618,7 @@ class AssignmentController(
      * @param principal is a [Principal] representing the user making the request
      * @return A String with the name of the relevant View
      */
+    @RequiresAssignmentOwnerOrACL
     @RequestMapping(value = ["/setup-git/{assignmentId}"], method = [(RequestMethod.POST)])
     fun connectAssignmentToGitRepository(@PathVariable assignmentId: String,
                                          @RequestParam(name = "reconnect", required = false) reconnect: Boolean = false,
@@ -637,12 +627,6 @@ class AssignmentController(
 
         val assignment = assignmentRepository.findById(assignmentId)
             .orElseThrow { EntityNotFoundException("Assignment $assignmentId not found") }
-
-        val acl = assignmentACLRepository.findByAssignmentId(assignmentId)
-
-        if (principal.realName() != assignment.ownerUserId && acl.find { it -> it.userId == principal.realName() } == null) {
-            throw IllegalAccessException("Assignments can only be changed by their owner or authorized teachers")
-        }
 
         if (assignment.gitRepositoryPrivKey == null) {
             LOG.warn("gitRepositoryUrl is null???")
@@ -846,6 +830,7 @@ class AssignmentController(
      * @param principal is a [Principal] representing the user making the request
      * @return A String with the name of the relevant View
      */
+    @RequiresAssignmentOwnerOrACL
     @RequestMapping(value = ["/toggle-status/{assignmentId}"], method = [(RequestMethod.GET), (RequestMethod.POST)])
     @Transactional  // this is needed since checkAssignmentFiles will insert assignmentTestMethods in the BD
     fun toggleAssignmentStatus(@PathVariable assignmentId: String,
@@ -856,12 +841,6 @@ class AssignmentController(
 
         val assignment = assignmentRepository.findById(assignmentId)
             .orElseThrow { EntityNotFoundException("Assignment $assignmentId not found") }
-
-        val acl = assignmentACLRepository.findByAssignmentId(assignmentId)
-
-        if (principal.realName() != assignment.ownerUserId && acl.find { it -> it.userId == principal.realName() } == null) {
-            throw IllegalAccessException("Assignments can only be changed by their owner or authorized teachers")
-        }
 
         if (!assignment.active) {
 
@@ -903,6 +882,7 @@ class AssignmentController(
      * @param principal is a [Principal] representing the user making the request
      * @return A String with the name of the relevant View
      */
+    @RequiresAssignmentOwnerOrACL
     @RequestMapping(value = ["/archive/{assignmentId}"], method = [(RequestMethod.POST)])
     fun archiveAssignment(@PathVariable assignmentId: String,
                           redirectAttributes: RedirectAttributes,
@@ -911,12 +891,6 @@ class AssignmentController(
         // check that it exists
         val assignment = assignmentRepository.findById(assignmentId)
             .orElseThrow { EntityNotFoundException("Assignment $assignmentId not found") }
-
-        val acl = assignmentACLRepository.findByAssignmentId(assignmentId)
-
-        if (principal.realName() != assignment.ownerUserId && acl.find { it -> it.userId == principal.realName() } == null) {
-            throw IllegalAccessException("Assignments can only be archived by their owner or authorized teachers")
-        }
 
         assignment.archived = true
         assignmentRepository.save(assignment)
@@ -937,6 +911,7 @@ class AssignmentController(
      * @param principal is a [Principal] representing the user making the request
      * @return A String with the name of the relevant View
      */
+    @RequiresAssignmentOwnerOrACL
     @RequestMapping(value = ["/markAllAsFinal/{assignmentId}"], method = [(RequestMethod.POST)])
     fun markAllSubmissionsAsFinal(@PathVariable assignmentId: String,
                                   redirectAttributes: RedirectAttributes,
@@ -944,12 +919,6 @@ class AssignmentController(
 
         val assignment = assignmentRepository.findById(assignmentId)
             .orElseThrow { EntityNotFoundException("Assignment $assignmentId not found") }
-
-        val acl = assignmentACLRepository.findByAssignmentId(assignment.id)
-
-        if (principal.realName() != assignment.ownerUserId && acl.find { it -> it.userId == principal.realName() } == null) {
-            throw IllegalAccessException("Submissions can only be marked as final by the assignment owner or authorized teachers")
-        }
 
         val submissionInfoList = submissionService.getSubmissionsList(assignment)
         submissionInfoList.forEach {
@@ -972,6 +941,7 @@ class AssignmentController(
      * @param assignmentId is a String, identifying the relevant Assignment
      * @return A ResponseEntity<String>
      */
+    @RequiresAssignmentOwnerOrACL
     @RequestMapping(value = ["/export/{assignmentId}"], method = [(RequestMethod.GET)])
     fun startAssignmentExport(@PathVariable assignmentId: String,
                               @RequestParam(name="includeSubmissions", required = false) includeSubmissions: Boolean = false,
@@ -979,12 +949,6 @@ class AssignmentController(
 
         val assignment = assignmentRepository.findById(assignmentId).orElse(null) ?:
         throw IllegalArgumentException("assignment ${assignmentId} is not registered")
-
-        val acl = assignmentACLRepository.findByAssignmentId(assignmentId)
-
-        if (principal.realName() != assignment.ownerUserId && acl.find { it.userId == principal.realName() } == null) {
-            throw IllegalAccessException("Exporting assignments is restricted to their owner or authorized teachers")
-        }
 
         val taskId = "${System.currentTimeMillis()}"
 
@@ -1106,6 +1070,8 @@ class AssignmentController(
      * @param principal The authenticated user
      * @return ResponseEntity with success or error message
      */
+    // Not annotated with @RequiresAssignmentOwnerOrACL: this is a JSON/AJAX endpoint that returns
+    // its own structured error body, which would be lost if Spring's AccessDeniedHandler intercepted it.
     @RequestMapping(value = ["/cooloff/{assignmentId}/disable"], method = [RequestMethod.POST])
     @ResponseBody
     fun disableCooloff(
@@ -1158,6 +1124,7 @@ class AssignmentController(
      * @param principal The authenticated user
      * @return ResponseEntity with success or error message
      */
+    // Not annotated with @RequiresAssignmentOwnerOrACL: same reason as disableCooloff above.
     @RequestMapping(value = ["/cooloff/{assignmentId}/enable"], method = [RequestMethod.POST])
     @ResponseBody
     fun enableCooloff(

--- a/src/main/kotlin/org/dropProject/controllers/ReportController.kt
+++ b/src/main/kotlin/org/dropProject/controllers/ReportController.kt
@@ -613,7 +613,8 @@ class ReportController(
     fun exportCSV(@PathVariable assignmentId: String,
                   @RequestParam(name="ellapsed", defaultValue = "true") includeEllapsed: Boolean, principal: Principal): ResponseEntity<String> {
 
-        val assignment = assignmentRepository.findById(assignmentId).orElse(null)
+        val assignment = assignmentRepository.findById(assignmentId)
+            .orElseThrow { IllegalArgumentException("Assignment $assignmentId not found") }
 
         val isGitBasedAssignment = assignment.submissionMethod == SubmissionMethod.GIT
 
@@ -743,7 +744,8 @@ class ReportController(
     fun getLeaderboard(@PathVariable assignmentId: String, model: ModelMap,
                        principal: Principal, request: HttpServletRequest): String {
 
-        val assignment = assignmentRepository.findById(assignmentId).orElse(null)
+        val assignment = assignmentRepository.findById(assignmentId)
+            .orElseThrow { IllegalArgumentException("Assignment $assignmentId not found") }
         if (!assignment.showLeaderBoard) {
             throw AccessDeniedException("Leaderboard for this assignment is not turned on")
         } else {

--- a/src/main/kotlin/org/dropProject/controllers/ReportController.kt
+++ b/src/main/kotlin/org/dropProject/controllers/ReportController.kt
@@ -30,6 +30,7 @@ import org.dropproject.extensions.formatDefault
 import org.dropproject.extensions.realName
 import org.dropproject.forms.SubmissionMethod
 import org.dropproject.repository.*
+import org.dropproject.security.RequiresAssignmentOwnerOrACL
 import org.dropproject.services.*
 import org.dropproject.storage.StorageService
 import org.slf4j.LoggerFactory
@@ -97,6 +98,7 @@ class ReportController(
      * @param request is an [HttpServletRequest]
      * @return A String with the name of the relevant View
      */
+    @RequiresAssignmentOwnerOrACL
     @RequestMapping(value = ["/signalledSubmissions/{assignmentId}"], method = [(RequestMethod.GET)])
     fun getSignaledGroupsOrSubmissions(@PathVariable assignmentId: String, model: ModelMap,
                                        principal: Principal, request: HttpServletRequest): String {
@@ -117,6 +119,7 @@ class ReportController(
      * @param request is an [HttpServletRequest]
      * @return A String with the name of the relevant View
      */
+    @RequiresAssignmentOwnerOrACL
     @RequestMapping(value = ["/report/{assignmentId}"], method = [(RequestMethod.GET)])
     fun getReport(@PathVariable assignmentId: String, model: ModelMap,
                   principal: Principal, request: HttpServletRequest): String {
@@ -136,6 +139,7 @@ class ReportController(
      * @param request is an [HttpServletRequest]
      * @return A String with the name of the relevant View
      */
+    @RequiresAssignmentOwnerOrACL
     @RequestMapping(value = ["/testMatrix/{assignmentId}"], method = [(RequestMethod.GET)])
     fun getTestMatrix(@PathVariable assignmentId: String, model: ModelMap,
                       principal: Principal, request: HttpServletRequest): String {
@@ -298,6 +302,7 @@ class ReportController(
      * @param response is an [HttpServletResponse]
      * @return A [FileSystemResource] containing a [ZipFile]
      */
+    @RequiresAssignmentOwnerOrACL
     @RequestMapping(value = ["/downloadOriginalAll/{assignmentId}"],
         method = [(RequestMethod.GET)], produces = [MediaType.APPLICATION_OCTET_STREAM_VALUE])
     @ResponseBody
@@ -306,11 +311,6 @@ class ReportController(
 
         val assignment = assignmentRepository.findById(assignmentId).orElse(null)
             ?: throw IllegalArgumentException("assignment ${assignmentId} is not registered")
-        val acl = assignmentACLRepository.findByAssignmentId(assignmentId)
-
-        if (principal.realName() != assignment.ownerUserId && acl.find { it -> it.userId == principal.realName() } == null) {
-            throw IllegalAccessError("Assignment reports can only be accessed by their owner or authorized teachers")
-        }
 
         if (assignment.submissionMethod != SubmissionMethod.UPLOAD) {
             throw IllegalArgumentException("downloadOriginalAll is only implemented for assignments whose submissions are through upload")
@@ -370,6 +370,7 @@ class ReportController(
      * @param response is an [HttpServletResponse]
      * @return A [FileSystemResource] containing a [ZipFile]
      */
+    @RequiresAssignmentOwnerOrACL
     @RequestMapping(value = ["/downloadMavenizedAll/{assignmentId}"],
         method = [(RequestMethod.GET)], produces = [MediaType.APPLICATION_OCTET_STREAM_VALUE])
     @ResponseBody
@@ -378,11 +379,6 @@ class ReportController(
 
         val assignment = assignmentRepository.findById(assignmentId).orElse(null)
             ?: throw IllegalArgumentException("assignment ${assignmentId} is not registered")
-        val acl = assignmentACLRepository.findByAssignmentId(assignmentId)
-
-        if (principal.realName() != assignment.ownerUserId && acl.find { it -> it.userId == principal.realName() } == null) {
-            throw IllegalAccessError("Assignment reports can only be accessed by their owner or authorized teachers")
-        }
 
         val submissionInfoList = submissionService.getSubmissionsList(assignment)
         val modulesList = mutableListOf<String>()
@@ -459,16 +455,12 @@ class ReportController(
 
     }
 
+    @RequiresAssignmentOwnerOrACL
     @RequestMapping(value = ["/checkPlagiarism/{assignmentId}"], method = [(RequestMethod.GET)])
     fun checkPlagiarism(@PathVariable assignmentId: String, model: ModelMap, principal: Principal): String {
 
         val assignment = assignmentRepository.findById(assignmentId).orElse(null)
             ?: throw IllegalArgumentException("assignment ${assignmentId} is not registered")
-        val acl = assignmentACLRepository.findByAssignmentId(assignmentId)
-
-        if (principal.realName() != assignment.ownerUserId && acl.find { it -> it.userId == principal.realName() } == null) {
-            throw IllegalAccessError("Assignment reports can only be accessed by their owner or authorized teachers")
-        }
 
         val submissionInfos = submissionService.getSubmissionsList(assignment, retrieveReport = false)
 
@@ -513,6 +505,7 @@ class ReportController(
     }
 
 
+    @RequiresAssignmentOwnerOrACL
     @RequestMapping(value = ["/downloadPlagiarismMatchReport/{assignmentId}"],
         method = [(RequestMethod.GET)], produces = [MediaType.APPLICATION_OCTET_STREAM_VALUE])
     @ResponseBody
@@ -521,11 +514,6 @@ class ReportController(
 
         val assignment = assignmentRepository.findById(assignmentId).orElse(null)
             ?: throw IllegalArgumentException("assignment ${assignmentId} is not registered")
-        val acl = assignmentACLRepository.findByAssignmentId(assignmentId)
-
-        if (principal.realName() != assignment.ownerUserId && acl.find { it.userId == principal.realName() } == null) {
-            throw IllegalAccessError("Plagiarism match reports can only be accessed by their owner or authorized teachers")
-        }
 
         val tempDir = FileSystemResource(System.getProperty("java.io.tmpdir")).file
         val plagiarismReportFile = File(tempDir, "dp-jplag-${assignmentId}-report.zip")
@@ -620,16 +608,12 @@ class ReportController(
      * @param assignmentId is a String, identifying the relevant Assignment
      * @return A ResponseEntity<String>
      */
+    @RequiresAssignmentOwnerOrACL
     @RequestMapping(value = ["/exportCSV/{assignmentId}"], method = [(RequestMethod.GET)])
     fun exportCSV(@PathVariable assignmentId: String,
                   @RequestParam(name="ellapsed", defaultValue = "true") includeEllapsed: Boolean, principal: Principal): ResponseEntity<String> {
 
         val assignment = assignmentRepository.findById(assignmentId).orElse(null)
-        val acl = assignmentACLRepository.findByAssignmentId(assignmentId)
-
-        if (principal.realName() != assignment.ownerUserId && acl.find { it -> it.userId == principal.realName() } == null) {
-            throw IllegalAccessError("Assignment reports can only be accessed by their owner or authorized teachers")
-        }
 
         val isGitBasedAssignment = assignment.submissionMethod == SubmissionMethod.GIT
 

--- a/src/main/kotlin/org/dropProject/repository/AssignmentRepository.kt
+++ b/src/main/kotlin/org/dropProject/repository/AssignmentRepository.kt
@@ -53,4 +53,7 @@ interface AssignmentRepository : JpaRepository<Assignment, String> {
     fun findAllByNumSubmissions(numSubmissions: Int): List<Assignment>
 
     fun countByTags_Id(tagId: Long): Long
+
+    @EntityGraph(attributePaths = ["tags", "assignmentTestMethods"])
+    fun findAllByArchivedFalseOrderById(): List<Assignment>
 }

--- a/src/main/kotlin/org/dropProject/security/RequiresAssignmentOwnerOrACL.kt
+++ b/src/main/kotlin/org/dropProject/security/RequiresAssignmentOwnerOrACL.kt
@@ -27,5 +27,5 @@ import org.springframework.security.access.prepost.PreAuthorize
  */
 @Target(AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
-@PreAuthorize("hasRole('DROP_PROJECT_ADMIN') or @authorizationService.isOwnerOrACL(#assignmentId, authentication.name)")
+@PreAuthorize("hasRole('DROP_PROJECT_ADMIN') or @authorizationService.isOwnerOrACL(#assignmentId, authentication)")
 annotation class RequiresAssignmentOwnerOrACL

--- a/src/main/kotlin/org/dropProject/security/RequiresAssignmentOwnerOrACL.kt
+++ b/src/main/kotlin/org/dropProject/security/RequiresAssignmentOwnerOrACL.kt
@@ -1,0 +1,31 @@
+/*-
+ * ========================LICENSE_START=================================
+ * DropProject
+ * %%
+ * Copyright (C) 2019 - 2026 Pedro Alves
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =========================LICENSE_END==================================
+ */
+package org.dropproject.security
+
+import org.springframework.security.access.prepost.PreAuthorize
+
+/**
+ * Restricts a controller method to the assignment's owner, any teacher listed in its ACL, or a DROP_PROJECT_ADMIN.
+ * The annotated method must have an `assignmentId: String` parameter.
+ */
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@PreAuthorize("hasRole('DROP_PROJECT_ADMIN') or @authorizationService.isOwnerOrACL(#assignmentId, authentication.name)")
+annotation class RequiresAssignmentOwnerOrACL

--- a/src/main/kotlin/org/dropProject/services/AssignmentService.kt
+++ b/src/main/kotlin/org/dropProject/services/AssignmentService.kt
@@ -40,6 +40,7 @@ import org.eclipse.jgit.api.Git
 import org.kohsuke.github.GitHub
 import org.slf4j.LoggerFactory
 import org.dropproject.config.DropProjectProperties
+import org.dropproject.security.RequiresAssignmentOwnerOrACL
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.scheduling.annotation.Async
@@ -131,6 +132,7 @@ class AssignmentService(
      * - "testMatrix" - meaning that the data is being loaded for the "Test Matrix" page; and
      * - "signalledSubmissions" - meaning that the data is being loaded for the "Signalled Groups" page.
      */
+    @RequiresAssignmentOwnerOrACL
     fun getAllSubmissionsForAssignment(assignmentId: String, principal: Principal, model: ModelMap,
                                        request: HttpServletRequest, includeTestDetails: Boolean = false,
                                        mode: String) {
@@ -138,12 +140,6 @@ class AssignmentService(
             .orElseThrow { EntityNotFoundException("Assignment $assignmentId not found") }
 
         model["assignment"] = assignment
-
-        val acl = assignmentACLRepository.findByAssignmentId(assignmentId)
-
-        if (principal.realName() != assignment.ownerUserId && acl.find { it.userId == principal.realName() } == null) {
-            throw IllegalAccessError("Assignment reports can only be accessed by their owner or authorized teachers")
-        }
 
         val submissionInfoList = submissionService.getSubmissionsList(assignment)
 
@@ -852,6 +848,7 @@ class AssignmentService(
      * @throws EntityNotFoundException if the assignment is not found
      * @throws IllegalAccessException if the user is not authorized to access the assignment
      */
+    @RequiresAssignmentOwnerOrACL
     @Transactional(readOnly = true)  // because of assignment.tags forced loading
     fun getAssignmentDetailData(assignmentId: String, principal: Principal, isAdmin: Boolean): AssignmentDetailResponse {
         val assignment = assignmentRepository.findById(assignmentId)
@@ -860,11 +857,6 @@ class AssignmentService(
         val assignees = assigneeRepository.findByAssignmentIdOrderByAuthorUserId(assignmentId)
         val acl = assignmentACLRepository.findByAssignmentId(assignmentId)
         val assignmentReports = assignmentReportRepository.findByAssignmentId(assignmentId)
-
-        // Authorization check
-        if (principal.realName() != assignment.ownerUserId && acl.find { it.userId == principal.realName() } == null) {
-            throw IllegalAccessException("Assignments can only be accessed by their owner or authorized teachers")
-        }
 
         val tests = assignmentTestMethodRepository.findByAssignmentId(assignmentId)
         

--- a/src/main/kotlin/org/dropProject/services/AuthorizationService.kt
+++ b/src/main/kotlin/org/dropProject/services/AuthorizationService.kt
@@ -34,6 +34,12 @@ class AuthorizationService(
     private val gitSubmissionRepository: GitSubmissionRepository
 ) {
 
+    fun isOwnerOrACL(assignmentId: String, principalName: String): Boolean {
+        val assignment = assignmentRepository.findById(assignmentId).orElse(null) ?: return false
+        return assignment.ownerUserId == principalName ||
+            assignmentACLRepository.existsByAssignmentIdAndUserId(assignmentId, principalName)
+    }
+
     fun canAccessAssignment(assignmentId: String, userId: String, isTeacher: Boolean): Boolean {
         val assignment = assignmentRepository.findById(assignmentId)
             .orElseThrow { throw ResponseStatusException(HttpStatus.NOT_FOUND, "Assignment not found") }

--- a/src/main/kotlin/org/dropProject/services/AuthorizationService.kt
+++ b/src/main/kotlin/org/dropProject/services/AuthorizationService.kt
@@ -19,10 +19,12 @@
  */
 package org.dropproject.services
 
+import org.dropproject.extensions.realName
 import org.dropproject.repository.AssignmentACLRepository
 import org.dropproject.repository.AssignmentRepository
 import org.dropproject.repository.GitSubmissionRepository
 import org.springframework.http.HttpStatus
+import org.springframework.security.core.Authentication
 import org.springframework.stereotype.Service
 import org.springframework.web.server.ResponseStatusException
 
@@ -34,10 +36,11 @@ class AuthorizationService(
     private val gitSubmissionRepository: GitSubmissionRepository
 ) {
 
-    fun isOwnerOrACL(assignmentId: String, principalName: String): Boolean {
+    fun isOwnerOrACL(assignmentId: String, authentication: Authentication): Boolean {
+        val userId = (authentication as java.security.Principal).realName()
         val assignment = assignmentRepository.findById(assignmentId).orElse(null) ?: return false
-        return assignment.ownerUserId == principalName ||
-            assignmentACLRepository.existsByAssignmentIdAndUserId(assignmentId, principalName)
+        return assignment.ownerUserId == userId ||
+            assignmentACLRepository.existsByAssignmentIdAndUserId(assignmentId, userId)
     }
 
     fun canAccessAssignment(assignmentId: String, userId: String, isTeacher: Boolean): Boolean {

--- a/src/main/resources/templates/admin-assignments-list.html
+++ b/src/main/resources/templates/admin-assignments-list.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+
+<head th:replace="~{layout/layout :: head (pageTitle='Drop Project - All assignments')}">
+</head>
+
+<body>
+<div th:replace="~{layout/layout :: header}"></div>
+
+<div class="container" style="max-width: 900px">
+
+    <h1 class="page-header">All Assignments</h1>
+
+    <table class="table myDataTable">
+        <thead>
+        <tr>
+            <th>Assignment ID</th>
+            <th>Tags</th>
+            <th>Owner</th>
+            <th>Last submission</th>
+            <th>Visibility</th>
+            <th>Submissions</th>
+            <th>Actions</th>
+        </tr>
+        </thead>
+        <tbody>
+        <!--/*@thymesVar id="assignments" type="java.util.ArrayList<org.dropproject.dao.Assignment>"*/-->
+        <tr th:each="assignment : ${assignments}">
+            <td th:text="${assignment.id}" th:title="${assignment.name}"></td>
+            <td class="space-between">
+                <span th:each="tag: ${assignment.tagsStr}" th:text="${tag}" class="label label-info" />
+            </td>
+            <td th:text="${assignment.ownerUserId}"></td>
+            <td th:if="${assignment.lastSubmissionDate != null}"
+                th:text="${#dates.format(assignment.lastSubmissionDate, 'dd/MMM HH:mm')}"
+                th:title="${#dates.format(assignment.lastSubmissionDate, 'dd/MM/yy HH:mm')}"
+                th:data-order="${assignment.getLastSubmissionDateAsTimestamp()}" class="text-center"></td>
+            <td th:if="${assignment.lastSubmissionDate == null}">-</td>
+            <td class="text-center">
+                <i th:if="${assignment.visibility == T(org.dropproject.dao.AssignmentVisibility).PUBLIC}" class="fa fa-globe" aria-hidden="true"
+                   title="Everyone can see"></i>
+                <i th:if="${assignment.visibility == T(org.dropproject.dao.AssignmentVisibility).ONLY_BY_LINK}" class="fa fa-link" aria-hidden="true"
+                   title="Must have a direct link"></i>
+                <i th:if="${assignment.visibility == T(org.dropproject.dao.AssignmentVisibility).PRIVATE}" class="fa fa-lock" aria-hidden="true"
+                   title="Only authorized users can see"></i>
+            </td>
+            <td class="text-center">
+                <a class="btn btn-default btn-sm" th:href="@{'/report/' + ${assignment.id}}"
+                   th:text="${assignment.numSubmissions}"></a>
+                <span class="glyphicon glyphicon-user" aria-hidden="true" th:text="${assignment.numUniqueSubmitters}"></span>
+            </td>
+            <td class="text-center text-nowrap">
+                <a th:href="@{'/assignment/info/' + ${assignment.id}}">
+                    <span class="glyphicon glyphicon-eye-open" aria-hidden="true"></span>
+                </a>
+                <a th:href="@{'/leaderboard/' + ${assignment.id}}" th:if="${assignment.showLeaderBoard}" alt="Show leaderboard">
+                    <img th:src="@{/img/trophy_16.png}" alt="Leaderboard" />
+                </a>
+            </td>
+        </tr>
+        </tbody>
+    </table>
+
+</div>
+
+<div th:replace="~{layout/layout :: footer}"></div>
+
+<script th:if="${!assignments.isEmpty()}" th:inline="none">
+    $(document).ready(function() {
+        $('.myDataTable').DataTable({
+            "paging": false,
+            "ordering": true,
+            "order": [[3, 'desc']],
+            "info": false,
+            "searching": true,
+            "columnDefs": [
+                {
+                    "targets": [1, 2, 4, 5, 6],
+                    "orderable": false
+                }
+            ]
+        });
+    });
+</script>
+
+</body>
+</html>

--- a/src/main/resources/templates/admin-assignments-list.html
+++ b/src/main/resources/templates/admin-assignments-list.html
@@ -9,7 +9,7 @@
 
 <div class="container" style="max-width: 900px">
 
-    <h1 class="page-header">All Assignments</h1>
+    <h1 class="page-header">All Non-Archived Assignments</h1>
 
     <table class="table myDataTable">
         <thead>

--- a/src/main/resources/templates/layout/layout.html
+++ b/src/main/resources/templates/layout/layout.html
@@ -85,6 +85,9 @@
                             <li>
                                 <a th:href="@{/admin/diskUsage}">Disk Usage</a>
                             </li>
+                            <li>
+                                <a th:href="@{/admin/assignments}">All Non-Archived Assignments</a>
+                            </li>
                         </ul>
                     </li>
                 </ul>

--- a/src/test/kotlin/org/dropProject/controllers/AdminControllerTests.kt
+++ b/src/test/kotlin/org/dropProject/controllers/AdminControllerTests.kt
@@ -25,6 +25,12 @@ import org.dropproject.dao.AssignmentTag
 import org.dropproject.dao.Submission
 import org.dropproject.dao.SubmissionStatus
 import org.dropproject.forms.SubmissionMethod
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.hasSize
+import org.hamcrest.Matchers.hasItem
+import org.hamcrest.Matchers.not
+import org.hamcrest.beans.HasPropertyWithValue.hasProperty
+import org.hamcrest.CoreMatchers.`is`
 import org.dropproject.repository.AssignmentRepository
 import org.dropproject.repository.AssignmentTagRepository
 import org.dropproject.repository.SubmissionRepository
@@ -46,6 +52,7 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.forwardedUrl
 
 @RunWith(SpringRunner::class)
 @AutoConfigureMockMvc
@@ -182,5 +189,68 @@ class AdminControllerTests {
         // Verify that the tag was deleted
         assertEquals(1, assignmentTagRepository.count()) // Only one tag should remain
         assertEquals("tag1", assignmentTagRepository.findAll()[0].name)
+    }
+
+    @Test
+    @WithMockUser("admin", roles = ["DROP_PROJECT_ADMIN"])
+    @DirtiesContext
+    fun `test getAllAssignments shows only non-archived assignments`() {
+        val activeAssignment = Assignment(id = "activeProj", name = "Active Project",
+            packageName = "org.dropProject.sampleAssignments.testProj", ownerUserId = "teacher1",
+            submissionMethod = SubmissionMethod.UPLOAD, active = true, gitRepositoryUrl = "git://dummyRepo",
+            gitRepositoryFolder = "activeProj")
+        val archivedAssignment = Assignment(id = "archivedProj", name = "Archived Project",
+            packageName = "org.dropProject.sampleAssignments.testProj", ownerUserId = "teacher2",
+            submissionMethod = SubmissionMethod.UPLOAD, active = false, archived = true,
+            gitRepositoryUrl = "git://dummyRepo", gitRepositoryFolder = "archivedProj")
+        assignmentRepository.save(activeAssignment)
+        assignmentRepository.save(archivedAssignment)
+
+        val result = mvc.perform(get("/admin/assignments"))
+            .andExpect(status().isOk)
+            .andExpect(view().name("admin-assignments-list"))
+            .andReturn()
+
+        @Suppress("UNCHECKED_CAST")
+        val assignments = result.modelAndView!!.modelMap["assignments"] as List<Assignment>
+
+        assertEquals(1, assignments.size)
+        assertEquals("activeProj", assignments[0].id)
+        assertEquals("teacher1", assignments[0].ownerUserId)
+    }
+
+    @Test
+    @WithMockUser("admin", roles = ["DROP_PROJECT_ADMIN"])
+    @DirtiesContext
+    fun `test getAllAssignments shows assignments from all owners`() {
+        val assignment1 = Assignment(id = "proj-teacher1", name = "Project Teacher 1",
+            packageName = "org.dropProject.sampleAssignments.testProj", ownerUserId = "teacher1",
+            submissionMethod = SubmissionMethod.UPLOAD, active = true, gitRepositoryUrl = "git://dummyRepo",
+            gitRepositoryFolder = "proj-teacher1")
+        val assignment2 = Assignment(id = "proj-teacher2", name = "Project Teacher 2",
+            packageName = "org.dropProject.sampleAssignments.testProj", ownerUserId = "teacher2",
+            submissionMethod = SubmissionMethod.UPLOAD, active = true, gitRepositoryUrl = "git://dummyRepo",
+            gitRepositoryFolder = "proj-teacher2")
+        assignmentRepository.save(assignment1)
+        assignmentRepository.save(assignment2)
+
+        val result = mvc.perform(get("/admin/assignments"))
+            .andExpect(status().isOk)
+            .andReturn()
+
+        @Suppress("UNCHECKED_CAST")
+        val assignments = result.modelAndView!!.modelMap["assignments"] as List<Assignment>
+
+        assertEquals(2, assignments.size)
+        assertEquals("teacher1", assignments.find { it.id == "proj-teacher1" }?.ownerUserId)
+        assertEquals("teacher2", assignments.find { it.id == "proj-teacher2" }?.ownerUserId)
+    }
+
+    @Test
+    @WithMockUser("teacher1", roles = ["TEACHER"])
+    @DirtiesContext
+    fun `test getAllAssignments is forbidden for non-admins`() {
+        mvc.perform(get("/admin/assignments"))
+            .andExpect(forwardedUrl("/access-denied.html"))
     }
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements:

* [x] Tests for the changes have been added/updated (if possible)
* [ ] Documentation has been updated/added if relevant
* [ ] Screenshots are attached to Github PR if visual/UI changes were made

### What is the current behavior?

ACL checks are duplicated across the code

### What is the new behavior?

Add a @RequiresAssignmentOwnerOrACL annotation to all the methods that were implementing the checks
Also added a new (admin-only) page to list all non-archived assignments (regardless of ownership or ACLs)
