### PR TITLE
Allow thread pool size to be configured via external file

### DIFF
--- a/src/main/kotlin/org/dropProject/config/AsyncConfig.kt
+++ b/src/main/kotlin/org/dropProject/config/AsyncConfig.kt
@@ -47,7 +47,7 @@ class AsyncConfig(
             LOG.info("Changed async execution timeout to $value seconds")
         }
 
-    var asyncThreadPoolSize: Int = 1
+    var asyncThreadPoolSize: Int = dropProjectProperties.async.threadPoolSize
         set(value) {
             field = value
             scheduler.poolSize = value
@@ -70,7 +70,7 @@ class AsyncConfig(
         LOG.info("Initializing task scheduler")
 
         scheduler = CancellableTaskScheduler(dropProjectProperties.async.timeout * 1000L)
-        scheduler.poolSize = 1
+        scheduler.poolSize = dropProjectProperties.async.threadPoolSize
         scheduler.initialize()
         return scheduler
     }

--- a/src/main/kotlin/org/dropProject/config/DropProjectProperties.kt
+++ b/src/main/kotlin/org/dropProject/config/DropProjectProperties.kt
@@ -102,7 +102,9 @@ data class DropProjectProperties(
 
     data class Async(
         /** Maximum time in seconds for async tasks (such as maven execution) */
-        val timeout: Int = 180
+        val timeout: Int = 180,
+        /** Number of threads in the async task executor thread pool */
+        val threadPoolSize: Int = 1
     )
 
     data class GitHub(

--- a/src/main/kotlin/org/dropProject/config/DropProjectProperties.kt
+++ b/src/main/kotlin/org/dropProject/config/DropProjectProperties.kt
@@ -19,7 +19,10 @@
  */
 package org.dropproject.config
 
+import jakarta.validation.Valid
+import jakarta.validation.constraints.Min
 import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.validation.annotation.Validated
 
 /**
  * Configuration properties for DropProject application.
@@ -30,6 +33,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  * Note: LTI properties are kept separate and continue to use @Value annotations
  * as they are profile-specific and managed differently.
  */
+@Validated
 @ConfigurationProperties(prefix = "drop-project")
 data class DropProjectProperties(
     
@@ -49,7 +53,7 @@ data class DropProjectProperties(
     val admin: Admin = Admin(),
     
     /** Async configuration */
-    val async: Async = Async(),
+    @field:Valid val async: Async = Async(),
     
     /** GitHub integration */
     val github: GitHub = GitHub(),
@@ -104,6 +108,7 @@ data class DropProjectProperties(
         /** Maximum time in seconds for async tasks (such as maven execution) */
         val timeout: Int = 180,
         /** Number of threads in the async task executor thread pool */
+        @field:Min(value = 1, message = "drop-project.async.thread-pool-size must be at least 1")
         val threadPoolSize: Int = 1
     )
 

--- a/src/main/resources/drop-project.properties
+++ b/src/main/resources/drop-project.properties
@@ -26,6 +26,9 @@ drop-project.admin.email=changethis@drop-project.properties
 # maximum time in seconds for async tasks (such as maven execution)
 drop-project.async.timeout=180
 
+# number of threads in the async task executor thread pool (default: 1)
+# drop-project.async.thread-pool-size=1
+
 # locale configuration (supported: pt_PT, en_US)
 spring.web.locale=en_US
 spring.web.locale-resolver=fixed


### PR DESCRIPTION
Allow thread pool size to be configured via drop-project.async.thread-pool-size property
